### PR TITLE
Make locks work again and add some minor fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2779,6 +2779,7 @@ dependencies = [
  "sha2",
  "sqlx",
  "tokio",
+ "tokio-async-drop",
  "tower",
  "tower-http",
  "tracing",
@@ -3447,6 +3448,12 @@ dependencies = [
  "tokio-macros",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "tokio-async-drop"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e57fbf1da3f18c8a95469f8973c138b0a99f4ae761885c3646b0c61139b0522"
 
 [[package]]
 name = "tokio-macros"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1973,9 +1973,9 @@ checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -2255,9 +2255,9 @@ checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -2265,9 +2265,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
@@ -2779,6 +2779,7 @@ dependencies = [
  "flate2",
  "lazy_static",
  "log",
+ "parking_lot",
  "prometheus",
  "reqwest",
  "serde",
@@ -2786,7 +2787,6 @@ dependencies = [
  "sha2",
  "sqlx",
  "tokio",
- "tokio-async-drop",
  "tower",
  "tower-http",
  "tracing",
@@ -3455,12 +3455,6 @@ dependencies = [
  "tokio-macros",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "tokio-async-drop"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e57fbf1da3f18c8a95469f8973c138b0a99f4ae761885c3646b0c61139b0522"
 
 [[package]]
 name = "tokio-macros"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,6 +113,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+
+[[package]]
 name = "async-compression"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2762,6 +2768,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 name = "s3dedup"
 version = "1.0.0-dev1"
 dependencies = [
+ "anyhow",
  "async-trait",
  "aws-config",
  "aws-sdk-s3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,4 @@ reqwest = { version = "0.12.0", features = ["json", "gzip"] }
 prometheus = "0.13.4"
 lazy_static = "1.5.0"
 tokio-async-drop = "0.1.0"
+anyhow = "1.0.100"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,4 @@ clap = { version = "4.5.0", features = ["derive"] }
 reqwest = { version = "0.12.0", features = ["json", "gzip"] }
 prometheus = "0.13.4"
 lazy_static = "1.5.0"
+tokio-async-drop = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,12 +23,12 @@ aws-sdk-s3 = { version = "1.52.0", features = ["behavior-version-latest"] }
 aws-config = { version = "1.5.0", features = ["behavior-version-latest"] }
 sha2 = "0.10.8"
 bytes = "1.5.0"
-async-trait = "0.1.77"
 flate2 = "1.0.28"
 urlencoding = "2.1.3"
 clap = { version = "4.5.0", features = ["derive"] }
 reqwest = { version = "0.12.0", features = ["json", "gzip"] }
 prometheus = "0.13.4"
 lazy_static = "1.5.0"
-tokio-async-drop = "0.1.0"
 anyhow = "1.0.100"
+parking_lot = { version = "0.12.4", features = ["arc_lock", "send_guard"] }
+async-trait = "0.1.77"

--- a/src/cleaner/mod.rs
+++ b/src/cleaner/mod.rs
@@ -1,5 +1,6 @@
 use crate::kvstorage::KVStorage;
 use crate::s3storage::S3Storage;
+use anyhow::Result;
 use serde::Deserialize;
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -95,7 +96,7 @@ impl Cleaner {
     }
 
     /// Run a full cleanup cycle
-    pub async fn run_cleanup(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    pub async fn run_cleanup(&self) -> Result<()> {
         let mut total_deletes = 0;
 
         // Case 1: Clean ref_files pointing to non-existent hashes
@@ -147,9 +148,7 @@ impl Cleaner {
     }
 
     /// Clean ref_files that point to non-existent hashes in refcount table
-    async fn clean_orphaned_ref_files(
-        &self,
-    ) -> Result<usize, Box<dyn std::error::Error + Send + Sync>> {
+    async fn clean_orphaned_ref_files(&self) -> Result<usize> {
         let mut deleted_count = 0;
         let mut offset = 0;
 
@@ -216,9 +215,7 @@ impl Cleaner {
     }
 
     /// Clean refcounts that have no corresponding ref_files
-    async fn clean_unreferenced_refcounts(
-        &self,
-    ) -> Result<usize, Box<dyn std::error::Error + Send + Sync>> {
+    async fn clean_unreferenced_refcounts(&self) -> Result<usize> {
         let mut deleted_count = 0;
         let mut offset = 0;
 
@@ -294,9 +291,7 @@ impl Cleaner {
     }
 
     /// Clean S3 objects that have no refcount or refcount = 0
-    async fn clean_unused_s3_objects(
-        &self,
-    ) -> Result<usize, Box<dyn std::error::Error + Send + Sync>> {
+    async fn clean_unused_s3_objects(&self) -> Result<usize> {
         let mut deleted_count = 0;
         let mut continuation_token: Option<String> = None;
 
@@ -347,9 +342,7 @@ impl Cleaner {
     }
 
     /// Clean logical_size entries that have no corresponding refcount
-    async fn clean_orphaned_logical_sizes(
-        &self,
-    ) -> Result<usize, Box<dyn std::error::Error + Send + Sync>> {
+    async fn clean_orphaned_logical_sizes(&self) -> Result<usize> {
         let mut deleted_count = 0;
         let mut offset = 0;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,7 @@
 use crate::cleaner::CleanerConfig;
 use crate::logging::LoggingConfig;
-use std::error::Error;
+use anyhow::Result;
+use anyhow::bail;
 
 pub use crate::kvstorage::KVStorageType;
 pub use crate::kvstorage::postgres::PostgresConfig;
@@ -45,7 +46,7 @@ pub struct BucketConfig {
 }
 
 impl Config {
-    pub fn new(path: &str) -> Result<Self, Box<dyn Error>> {
+    pub fn new(path: &str) -> Result<Self> {
         let config_str = std::fs::read_to_string(path)?;
         let mut config: Config = serde_json::from_str(config_str.as_str())?;
 
@@ -58,7 +59,7 @@ impl Config {
     }
 
     /// Create a default config from environment variables only
-    pub fn from_env() -> Result<Self, Box<dyn Error>> {
+    pub fn from_env() -> Result<Self> {
         let logging = LoggingConfig {
             level: std::env::var("LOG_LEVEL").unwrap_or_else(|_| "info".to_string()),
             json: std::env::var("LOG_JSON")
@@ -149,13 +150,13 @@ impl BucketConfig {
     }
 
     /// Create a bucket config from environment variables only
-    fn from_env() -> Result<Self, Box<dyn Error>> {
+    fn from_env() -> Result<Self> {
         let kvstorage_type_str =
             std::env::var("KVSTORAGE_TYPE").unwrap_or_else(|_| "sqlite".to_string());
         let kvstorage_type = match kvstorage_type_str.as_str() {
             "postgres" => KVStorageType::Postgres,
             "sqlite" => KVStorageType::SQLite,
-            _ => return Err(format!("Invalid KVSTORAGE_TYPE: {}", kvstorage_type_str).into()),
+            _ => bail!("Invalid KVSTORAGE_TYPE: {}", kvstorage_type_str),
         };
 
         let sqlite = if matches!(kvstorage_type, KVStorageType::SQLite) {
@@ -194,7 +195,7 @@ impl BucketConfig {
             std::env::var("S3STORAGE_TYPE").unwrap_or_else(|_| "minio".to_string());
         let s3storage_type = match s3storage_type_str.as_str() {
             "minio" => S3StorageType::MinIO,
-            _ => return Err(format!("Invalid S3STORAGE_TYPE: {}", s3storage_type_str).into()),
+            _ => bail!("Invalid S3STORAGE_TYPE: {}", s3storage_type_str),
         };
 
         let minio = if matches!(s3storage_type, S3StorageType::MinIO) {

--- a/src/filetracker_client/mod.rs
+++ b/src/filetracker_client/mod.rs
@@ -1,6 +1,8 @@
+use anyhow::Result;
+use anyhow::anyhow;
+use anyhow::bail;
 use chrono::DateTime;
 use reqwest::{Client, StatusCode};
-use std::error::Error;
 use tracing::{debug, error, warn};
 
 #[derive(Clone)]
@@ -29,11 +31,7 @@ impl FiletrackerClient {
     }
 
     /// List all files under a path with modification time before the given timestamp
-    pub async fn list_files(
-        &self,
-        path: &str,
-        timestamp: i64,
-    ) -> Result<Vec<String>, Box<dyn Error + Send + Sync>> {
+    pub async fn list_files(&self, path: &str, timestamp: i64) -> Result<Vec<String>> {
         // The original filetracker expects a Unix timestamp as a string, not RFC2822
         let url = format!(
             "{}/list/{}?last_modified={}",
@@ -46,7 +44,7 @@ impl FiletrackerClient {
 
         if !response.status().is_success() {
             error!("Failed to list files: HTTP {}", response.status());
-            return Err(format!("HTTP {}", response.status()).into());
+            bail!("HTTP {}", response.status())
         }
 
         let body = response.text().await?;
@@ -61,19 +59,19 @@ impl FiletrackerClient {
     }
 
     /// Get a file from filetracker
-    pub async fn get_file(&self, path: &str) -> Result<FileMetadata, Box<dyn Error + Send + Sync>> {
+    pub async fn get_file(&self, path: &str) -> Result<FileMetadata> {
         let url = format!("{}/files/{}", self.base_url, path);
         debug!("Getting file from filetracker: {}", url);
 
         let response = self.client.get(&url).send().await?;
 
         if response.status() == StatusCode::NOT_FOUND {
-            return Err("File not found".into());
+            bail!("File not found");
         }
 
         if !response.status().is_success() {
             error!("Failed to get file: HTTP {}", response.status());
-            return Err(format!("HTTP {}", response.status()).into());
+            bail!("HTTP {}", response.status())
         }
 
         // Extract headers
@@ -81,7 +79,7 @@ impl FiletrackerClient {
             .headers()
             .get("Last-Modified")
             .and_then(|v| v.to_str().ok())
-            .ok_or("Missing Last-Modified header")?;
+            .ok_or_else(|| anyhow!("Missing Last-Modified header"))?;
 
         let last_modified = DateTime::parse_from_rfc2822(last_modified_str)?.timestamp();
 
@@ -126,9 +124,9 @@ impl FiletrackerClient {
         logical_size: usize,
         sha256_checksum: &str,
         is_compressed: bool,
-    ) -> Result<(), Box<dyn Error + Send + Sync>> {
+    ) -> Result<()> {
         let timestamp_rfc2822 = DateTime::from_timestamp(last_modified, 0)
-            .ok_or("Invalid timestamp")?
+            .ok_or_else(|| anyhow!("Invalid timestamp"))?
             .to_rfc2822();
 
         let url = format!(
@@ -154,7 +152,7 @@ impl FiletrackerClient {
 
         if !response.status().is_success() {
             error!("Failed to put file: HTTP {}", response.status());
-            return Err(format!("HTTP {}", response.status()).into());
+            bail!("HTTP {}", response.status())
         }
 
         debug!("Put file to filetracker successfully");
@@ -162,13 +160,9 @@ impl FiletrackerClient {
     }
 
     /// Delete a file from filetracker
-    pub async fn delete_file(
-        &self,
-        path: &str,
-        last_modified: i64,
-    ) -> Result<(), Box<dyn Error + Send + Sync>> {
+    pub async fn delete_file(&self, path: &str, last_modified: i64) -> Result<()> {
         let timestamp_rfc2822 = DateTime::from_timestamp(last_modified, 0)
-            .ok_or("Invalid timestamp")?
+            .ok_or_else(|| anyhow!("Invalid timestamp"))?
             .to_rfc2822();
 
         let url = format!(
@@ -189,7 +183,7 @@ impl FiletrackerClient {
 
         if !response.status().is_success() {
             error!("Failed to delete file: HTTP {}", response.status());
-            return Err(format!("HTTP {}", response.status()).into());
+            bail!("HTTP {}", response.status())
         }
 
         debug!("Deleted file from filetracker successfully");

--- a/src/kvstorage/mod.rs
+++ b/src/kvstorage/mod.rs
@@ -1,6 +1,6 @@
 use crate::config::BucketConfig;
+use anyhow::Result;
 use serde::Deserialize;
-use std::error::Error;
 use tracing::{debug, info};
 
 mod pooled;
@@ -16,36 +16,19 @@ pub enum KVStorageType {
 }
 
 pub(crate) trait KVStorageTrait {
-    async fn new(config: &BucketConfig) -> Result<Box<Self>, Box<dyn Error + Send + Sync>>
+    async fn new(config: &BucketConfig) -> Result<Box<Self>>
     where
         Self: Sized;
 
-    async fn setup(&mut self) -> Result<(), Box<dyn Error + Send + Sync>>;
-    async fn get_ref_count(
-        &mut self,
-        bucket: &str,
-        hash: &str,
-    ) -> Result<i32, Box<dyn Error + Send + Sync>>;
-    async fn set_ref_count(
-        &mut self,
-        bucket: &str,
-        hash: &str,
-        ref_cnt: i32,
-    ) -> Result<(), Box<dyn Error + Send + Sync>>;
-    async fn increment_ref_count(
-        &mut self,
-        bucket: &str,
-        hash: &str,
-    ) -> Result<(), Box<dyn Error + Send + Sync>> {
+    async fn setup(&mut self) -> Result<()>;
+    async fn get_ref_count(&mut self, bucket: &str, hash: &str) -> Result<i32>;
+    async fn set_ref_count(&mut self, bucket: &str, hash: &str, ref_cnt: i32) -> Result<()>;
+    async fn increment_ref_count(&mut self, bucket: &str, hash: &str) -> Result<()> {
         let cnt = self.get_ref_count(bucket, hash).await?;
         self.set_ref_count(bucket, hash, cnt + 1).await
     }
 
-    async fn decrement_ref_count(
-        &mut self,
-        bucket: &str,
-        hash: &str,
-    ) -> Result<(), Box<dyn Error + Send + Sync>> {
+    async fn decrement_ref_count(&mut self, bucket: &str, hash: &str) -> Result<()> {
         let cnt = self.get_ref_count(bucket, hash).await?;
         if cnt == 0 {
             return Ok(());
@@ -53,51 +36,16 @@ pub(crate) trait KVStorageTrait {
         self.set_ref_count(bucket, hash, cnt - 1).await
     }
 
-    async fn get_modified(
-        &mut self,
-        bucket: &str,
-        path: &str,
-    ) -> Result<i64, Box<dyn Error + Send + Sync>>;
-    async fn set_modified(
-        &mut self,
-        bucket: &str,
-        path: &str,
-        modified: i64,
-    ) -> Result<(), Box<dyn Error + Send + Sync>>;
-    async fn delete_modified(
-        &mut self,
-        bucket: &str,
-        path: &str,
-    ) -> Result<(), Box<dyn Error + Send + Sync>>;
+    async fn get_modified(&mut self, bucket: &str, path: &str) -> Result<i64>;
+    async fn set_modified(&mut self, bucket: &str, path: &str, modified: i64) -> Result<()>;
+    async fn delete_modified(&mut self, bucket: &str, path: &str) -> Result<()>;
 
-    async fn get_ref_file(
-        &mut self,
-        bucket: &str,
-        path: &str,
-    ) -> Result<String, Box<dyn Error + Send + Sync>>;
-    async fn set_ref_file(
-        &mut self,
-        bucket: &str,
-        path: &str,
-        hash: &str,
-    ) -> Result<(), Box<dyn Error + Send + Sync>>;
-    async fn delete_ref_file(
-        &mut self,
-        bucket: &str,
-        path: &str,
-    ) -> Result<(), Box<dyn Error + Send + Sync>>;
+    async fn get_ref_file(&mut self, bucket: &str, path: &str) -> Result<String>;
+    async fn set_ref_file(&mut self, bucket: &str, path: &str, hash: &str) -> Result<()>;
+    async fn delete_ref_file(&mut self, bucket: &str, path: &str) -> Result<()>;
 
-    async fn get_logical_size(
-        &mut self,
-        bucket: &str,
-        hash: &str,
-    ) -> Result<usize, Box<dyn Error + Send + Sync>>;
-    async fn set_logical_size(
-        &mut self,
-        bucket: &str,
-        hash: &str,
-        size: usize,
-    ) -> Result<(), Box<dyn Error + Send + Sync>>;
+    async fn get_logical_size(&mut self, bucket: &str, hash: &str) -> Result<usize>;
+    async fn set_logical_size(&mut self, bucket: &str, hash: &str, size: usize) -> Result<()>;
 
     /// List all files under a given path prefix that were modified at or before the given timestamp
     async fn list_files(
@@ -105,7 +53,7 @@ pub(crate) trait KVStorageTrait {
         bucket: &str,
         path_prefix: &str,
         timestamp: i64,
-    ) -> Result<Vec<String>, Box<dyn Error + Send + Sync>>;
+    ) -> Result<Vec<String>>;
 
     // Batched methods for cleaner
     /// List ref_file entries in batches (path, hash)
@@ -114,7 +62,7 @@ pub(crate) trait KVStorageTrait {
         bucket: &str,
         limit: usize,
         offset: usize,
-    ) -> Result<Vec<(String, String)>, Box<dyn Error + Send + Sync>>;
+    ) -> Result<Vec<(String, String)>>;
 
     /// List refcount entries in batches (hash, count)
     async fn list_refcounts_batch(
@@ -122,7 +70,7 @@ pub(crate) trait KVStorageTrait {
         bucket: &str,
         limit: usize,
         offset: usize,
-    ) -> Result<Vec<(String, i32)>, Box<dyn Error + Send + Sync>>;
+    ) -> Result<Vec<(String, i32)>>;
 
     /// List logical_size entries in batches (hash)
     async fn list_logical_sizes_batch(
@@ -130,21 +78,13 @@ pub(crate) trait KVStorageTrait {
         bucket: &str,
         limit: usize,
         offset: usize,
-    ) -> Result<Vec<String>, Box<dyn Error + Send + Sync>>;
+    ) -> Result<Vec<String>>;
 
     /// Delete a refcount entry
-    async fn delete_refcount(
-        &mut self,
-        bucket: &str,
-        hash: &str,
-    ) -> Result<(), Box<dyn Error + Send + Sync>>;
+    async fn delete_refcount(&mut self, bucket: &str, hash: &str) -> Result<()>;
 
     /// Delete a logical_size entry
-    async fn delete_logical_size(
-        &mut self,
-        bucket: &str,
-        hash: &str,
-    ) -> Result<(), Box<dyn Error + Send + Sync>>;
+    async fn delete_logical_size(&mut self, bucket: &str, hash: &str) -> Result<()>;
 }
 
 #[derive(Clone)]
@@ -154,7 +94,7 @@ pub enum KVStorage {
 }
 
 impl KVStorage {
-    pub async fn new(config: &BucketConfig) -> Result<Box<Self>, Box<dyn Error + Send + Sync>> {
+    pub async fn new(config: &BucketConfig) -> Result<Box<Self>> {
         match config.kvstorage_type {
             KVStorageType::Postgres => {
                 info!("Using Postgres as KV storage");
@@ -172,7 +112,7 @@ impl KVStorage {
     /**
      * Setup the KV storage.
      */
-    pub async fn setup(&mut self) -> Result<(), Box<dyn Error + Send + Sync>> {
+    pub async fn setup(&mut self) -> Result<()> {
         match self {
             KVStorage::Postgres(storage) => storage.setup().await,
             KVStorage::SQLite(storage) => storage.setup().await,
@@ -183,11 +123,7 @@ impl KVStorage {
      * Get the reference count for a hash.
      * If the hash does not exist, return 0.
      */
-    pub async fn get_ref_count(
-        &mut self,
-        bucket: &str,
-        hash: &str,
-    ) -> Result<i32, Box<dyn Error + Send + Sync>> {
+    pub async fn get_ref_count(&mut self, bucket: &str, hash: &str) -> Result<i32> {
         debug!("Getting ref count for bucket: {}, hash: {}", bucket, hash);
         match self {
             KVStorage::Postgres(storage) => storage.get_ref_count(bucket, hash).await,
@@ -198,12 +134,7 @@ impl KVStorage {
     /**
      * Set the reference count for a hash.
      */
-    pub async fn set_ref_count(
-        &mut self,
-        bucket: &str,
-        hash: &str,
-        ref_cnt: i32,
-    ) -> Result<(), Box<dyn Error + Send + Sync>> {
+    pub async fn set_ref_count(&mut self, bucket: &str, hash: &str, ref_cnt: i32) -> Result<()> {
         debug!(
             "Setting ref count for bucket: {}, hash: {} to {}",
             bucket, hash, ref_cnt
@@ -217,11 +148,7 @@ impl KVStorage {
     /**
      * Increment the reference count for a hash.
      */
-    pub async fn increment_ref_count(
-        &mut self,
-        bucket: &str,
-        hash: &str,
-    ) -> Result<(), Box<dyn Error + Send + Sync>> {
+    pub async fn increment_ref_count(&mut self, bucket: &str, hash: &str) -> Result<()> {
         debug!(
             "Incrementing ref count for bucket: {}, hash: {}",
             bucket, hash
@@ -236,11 +163,7 @@ impl KVStorage {
      * Decrement the reference count for a hash.
      * If the reference count is already 0, do nothing.
      */
-    pub async fn decrement_ref_count(
-        &mut self,
-        bucket: &str,
-        hash: &str,
-    ) -> Result<(), Box<dyn Error + Send + Sync>> {
+    pub async fn decrement_ref_count(&mut self, bucket: &str, hash: &str) -> Result<()> {
         debug!(
             "Decrementing ref count for bucket: {}, hash: {}",
             bucket, hash
@@ -255,11 +178,7 @@ impl KVStorage {
      * Get the modified time for a path.
      * If the path does not exist, return 0.
      */
-    pub async fn get_modified(
-        &mut self,
-        bucket: &str,
-        path: &str,
-    ) -> Result<i64, Box<dyn Error + Send + Sync>> {
+    pub async fn get_modified(&mut self, bucket: &str, path: &str) -> Result<i64> {
         debug!(
             "Getting modified time for bucket: {}, path: {}",
             bucket, path
@@ -273,12 +192,7 @@ impl KVStorage {
     /**
      * Set the modified time for a path.
      */
-    pub async fn set_modified(
-        &mut self,
-        bucket: &str,
-        path: &str,
-        modified: i64,
-    ) -> Result<(), Box<dyn Error + Send + Sync>> {
+    pub async fn set_modified(&mut self, bucket: &str, path: &str, modified: i64) -> Result<()> {
         debug!(
             "Setting modified time for bucket: {}, path: {} to {}",
             bucket, path, modified
@@ -292,11 +206,7 @@ impl KVStorage {
     /**
      * Delete the modified time for a path.
      */
-    pub async fn delete_modified(
-        &mut self,
-        bucket: &str,
-        path: &str,
-    ) -> Result<(), Box<dyn Error + Send + Sync>> {
+    pub async fn delete_modified(&mut self, bucket: &str, path: &str) -> Result<()> {
         debug!(
             "Deleting modified time for bucket: {}, path: {}",
             bucket, path
@@ -311,11 +221,7 @@ impl KVStorage {
      * Get the reference file for a path.
      * If the path does not exist, return an empty string.
      */
-    pub async fn get_ref_file(
-        &mut self,
-        bucket: &str,
-        path: &str,
-    ) -> Result<String, Box<dyn Error + Send + Sync>> {
+    pub async fn get_ref_file(&mut self, bucket: &str, path: &str) -> Result<String> {
         debug!("Getting ref file for bucket: {}, path: {}", bucket, path);
         match self {
             KVStorage::Postgres(storage) => storage.get_ref_file(bucket, path).await,
@@ -326,12 +232,7 @@ impl KVStorage {
     /**
      * Set the reference file for a path.
      */
-    pub async fn set_ref_file(
-        &mut self,
-        bucket: &str,
-        path: &str,
-        hash: &str,
-    ) -> Result<(), Box<dyn Error + Send + Sync>> {
+    pub async fn set_ref_file(&mut self, bucket: &str, path: &str, hash: &str) -> Result<()> {
         debug!(
             "Setting ref file for bucket: {}, path: {} to {}",
             bucket, path, hash
@@ -345,11 +246,7 @@ impl KVStorage {
     /**
      * Delete the reference file for a path.
      */
-    pub async fn delete_ref_file(
-        &mut self,
-        bucket: &str,
-        path: &str,
-    ) -> Result<(), Box<dyn Error + Send + Sync>> {
+    pub async fn delete_ref_file(&mut self, bucket: &str, path: &str) -> Result<()> {
         debug!("Deleting ref file for bucket: {}, path: {}", bucket, path);
         match self {
             KVStorage::Postgres(storage) => storage.delete_ref_file(bucket, path).await,
@@ -361,11 +258,7 @@ impl KVStorage {
      * Get the logical size for a hash.
      * If the hash does not exist, return 0.
      */
-    pub async fn get_logical_size(
-        &mut self,
-        bucket: &str,
-        hash: &str,
-    ) -> Result<usize, Box<dyn Error + Send + Sync>> {
+    pub async fn get_logical_size(&mut self, bucket: &str, hash: &str) -> Result<usize> {
         debug!(
             "Getting logical size for bucket: {}, hash: {}",
             bucket, hash
@@ -379,12 +272,7 @@ impl KVStorage {
     /**
      * Set the logical size for a hash.
      */
-    pub async fn set_logical_size(
-        &mut self,
-        bucket: &str,
-        hash: &str,
-        size: usize,
-    ) -> Result<(), Box<dyn Error + Send + Sync>> {
+    pub async fn set_logical_size(&mut self, bucket: &str, hash: &str, size: usize) -> Result<()> {
         debug!(
             "Setting logical size for bucket: {}, hash: {} to {}",
             bucket, hash, size
@@ -403,7 +291,7 @@ impl KVStorage {
         bucket: &str,
         path_prefix: &str,
         timestamp: i64,
-    ) -> Result<Vec<String>, Box<dyn Error + Send + Sync>> {
+    ) -> Result<Vec<String>> {
         debug!(
             "Listing files for bucket: {}, prefix: {}, timestamp: {}",
             bucket, path_prefix, timestamp
@@ -421,7 +309,7 @@ impl KVStorage {
         bucket: &str,
         limit: usize,
         offset: usize,
-    ) -> Result<Vec<(String, String)>, Box<dyn Error + Send + Sync>> {
+    ) -> Result<Vec<(String, String)>> {
         match self {
             KVStorage::Postgres(storage) => {
                 storage.list_ref_files_batch(bucket, limit, offset).await
@@ -435,7 +323,7 @@ impl KVStorage {
         bucket: &str,
         limit: usize,
         offset: usize,
-    ) -> Result<Vec<(String, i32)>, Box<dyn Error + Send + Sync>> {
+    ) -> Result<Vec<(String, i32)>> {
         match self {
             KVStorage::Postgres(storage) => {
                 storage.list_refcounts_batch(bucket, limit, offset).await
@@ -449,7 +337,7 @@ impl KVStorage {
         bucket: &str,
         limit: usize,
         offset: usize,
-    ) -> Result<Vec<String>, Box<dyn Error + Send + Sync>> {
+    ) -> Result<Vec<String>> {
         match self {
             KVStorage::Postgres(storage) => {
                 storage
@@ -464,22 +352,14 @@ impl KVStorage {
         }
     }
 
-    pub async fn delete_refcount(
-        &mut self,
-        bucket: &str,
-        hash: &str,
-    ) -> Result<(), Box<dyn Error + Send + Sync>> {
+    pub async fn delete_refcount(&mut self, bucket: &str, hash: &str) -> Result<()> {
         match self {
             KVStorage::Postgres(storage) => storage.delete_refcount(bucket, hash).await,
             KVStorage::SQLite(storage) => storage.delete_refcount(bucket, hash).await,
         }
     }
 
-    pub async fn delete_logical_size(
-        &mut self,
-        bucket: &str,
-        hash: &str,
-    ) -> Result<(), Box<dyn Error + Send + Sync>> {
+    pub async fn delete_logical_size(&mut self, bucket: &str, hash: &str) -> Result<()> {
         match self {
             KVStorage::Postgres(storage) => storage.delete_logical_size(bucket, hash).await,
             KVStorage::SQLite(storage) => storage.delete_logical_size(bucket, hash).await,

--- a/src/kvstorage/postgres.rs
+++ b/src/kvstorage/postgres.rs
@@ -1,9 +1,9 @@
 use crate::config::BucketConfig;
 use crate::kvstorage::KVStorageTrait;
+use anyhow::Result;
 use serde::Deserialize;
 use sqlx::PgPool;
 use sqlx::postgres::PgPoolOptions;
-use std::error::Error;
 use tracing::debug;
 
 #[derive(Debug, Clone, Deserialize)]
@@ -31,7 +31,7 @@ impl Postgres {
 }
 
 impl KVStorageTrait for Postgres {
-    async fn new(config: &BucketConfig) -> Result<Box<Self>, Box<dyn Error + Send + Sync>> {
+    async fn new(config: &BucketConfig) -> Result<Box<Self>> {
         let pg_config = config.postgres.as_ref().unwrap();
         let db_url = format!(
             "postgres://{}:{}@{}:{}/{}",
@@ -47,7 +47,7 @@ impl KVStorageTrait for Postgres {
             bucket: config.name.clone(),
         }))
     }
-    async fn setup(&mut self) -> Result<(), Box<dyn Error + Send + Sync>> {
+    async fn setup(&mut self) -> Result<()> {
         // PostgreSQL doesn't support multiple statements in a single query
         // Create tables with bucket-specific names to allow parallel tests
         let refcount_table = self.table_name("refcount");
@@ -106,11 +106,7 @@ impl KVStorageTrait for Postgres {
         Ok(())
     }
 
-    async fn get_ref_count(
-        &mut self,
-        bucket: &str,
-        hash: &str,
-    ) -> Result<i32, Box<dyn Error + Send + Sync>> {
+    async fn get_ref_count(&mut self, bucket: &str, hash: &str) -> Result<i32> {
         let table = self.table_name("refcount");
         let query = format!(
             "SELECT refcount FROM {} WHERE bucket = $1 AND hash = $2",
@@ -128,12 +124,7 @@ impl KVStorageTrait for Postgres {
         }
     }
 
-    async fn set_ref_count(
-        &mut self,
-        bucket: &str,
-        hash: &str,
-        ref_cnt: i32,
-    ) -> Result<(), Box<dyn Error + Send + Sync>> {
+    async fn set_ref_count(&mut self, bucket: &str, hash: &str, ref_cnt: i32) -> Result<()> {
         let table = self.table_name("refcount");
         let query = format!(
             "INSERT INTO {} (bucket, hash, refcount) VALUES ($1, $2, $3)
@@ -149,11 +140,7 @@ impl KVStorageTrait for Postgres {
         Ok(())
     }
 
-    async fn get_modified(
-        &mut self,
-        bucket: &str,
-        path: &str,
-    ) -> Result<i64, Box<dyn Error + Send + Sync>> {
+    async fn get_modified(&mut self, bucket: &str, path: &str) -> Result<i64> {
         let table = self.table_name("modified");
         let query = format!(
             "SELECT modified FROM {} WHERE bucket = $1 AND path = $2",
@@ -171,12 +158,7 @@ impl KVStorageTrait for Postgres {
         }
     }
 
-    async fn set_modified(
-        &mut self,
-        bucket: &str,
-        path: &str,
-        modified: i64,
-    ) -> Result<(), Box<dyn Error + Send + Sync>> {
+    async fn set_modified(&mut self, bucket: &str, path: &str, modified: i64) -> Result<()> {
         let table = self.table_name("modified");
         let query = format!(
             "INSERT INTO {} (bucket, path, modified) VALUES ($1, $2, $3)
@@ -192,11 +174,7 @@ impl KVStorageTrait for Postgres {
         Ok(())
     }
 
-    async fn delete_modified(
-        &mut self,
-        bucket: &str,
-        path: &str,
-    ) -> Result<(), Box<dyn Error + Send + Sync>> {
+    async fn delete_modified(&mut self, bucket: &str, path: &str) -> Result<()> {
         let table = self.table_name("modified");
         let query = format!("DELETE FROM {} WHERE bucket = $1 AND path = $2", table);
         sqlx::query(&query)
@@ -207,11 +185,7 @@ impl KVStorageTrait for Postgres {
         Ok(())
     }
 
-    async fn get_ref_file(
-        &mut self,
-        bucket: &str,
-        path: &str,
-    ) -> Result<String, Box<dyn Error + Send + Sync>> {
+    async fn get_ref_file(&mut self, bucket: &str, path: &str) -> Result<String> {
         let table = self.table_name("ref_file");
         let query = format!("SELECT hash FROM {} WHERE bucket = $1 AND path = $2", table);
         let result: Result<(String,), sqlx::Error> = sqlx::query_as(&query)
@@ -226,12 +200,7 @@ impl KVStorageTrait for Postgres {
         }
     }
 
-    async fn set_ref_file(
-        &mut self,
-        bucket: &str,
-        path: &str,
-        hash: &str,
-    ) -> Result<(), Box<dyn Error + Send + Sync>> {
+    async fn set_ref_file(&mut self, bucket: &str, path: &str, hash: &str) -> Result<()> {
         let table = self.table_name("ref_file");
         let query = format!(
             "INSERT INTO {} (bucket, path, hash) VALUES ($1, $2, $3)
@@ -247,11 +216,7 @@ impl KVStorageTrait for Postgres {
         Ok(())
     }
 
-    async fn delete_ref_file(
-        &mut self,
-        bucket: &str,
-        path: &str,
-    ) -> Result<(), Box<dyn Error + Send + Sync>> {
+    async fn delete_ref_file(&mut self, bucket: &str, path: &str) -> Result<()> {
         let table = self.table_name("ref_file");
         let query = format!("DELETE FROM {} WHERE bucket = $1 AND path = $2", table);
         sqlx::query(&query)
@@ -262,11 +227,7 @@ impl KVStorageTrait for Postgres {
         Ok(())
     }
 
-    async fn get_logical_size(
-        &mut self,
-        bucket: &str,
-        hash: &str,
-    ) -> Result<usize, Box<dyn Error + Send + Sync>> {
+    async fn get_logical_size(&mut self, bucket: &str, hash: &str) -> Result<usize> {
         let table = self.table_name("logical_size");
         let query = format!(
             "SELECT logical_size FROM {} WHERE bucket = $1 AND hash = $2",
@@ -284,12 +245,7 @@ impl KVStorageTrait for Postgres {
         }
     }
 
-    async fn set_logical_size(
-        &mut self,
-        bucket: &str,
-        hash: &str,
-        size: usize,
-    ) -> Result<(), Box<dyn Error + Send + Sync>> {
+    async fn set_logical_size(&mut self, bucket: &str, hash: &str, size: usize) -> Result<()> {
         let table = self.table_name("logical_size");
         let query = format!(
             "INSERT INTO {} (bucket, hash, logical_size) VALUES ($1, $2, $3) ON CONFLICT (bucket, hash) DO UPDATE SET logical_size = $3",
@@ -309,7 +265,7 @@ impl KVStorageTrait for Postgres {
         bucket: &str,
         path_prefix: &str,
         timestamp: i64,
-    ) -> Result<Vec<String>, Box<dyn Error + Send + Sync>> {
+    ) -> Result<Vec<String>> {
         let table = self.table_name("modified");
         let pattern = format!("{}%", path_prefix);
         let query = format!(
@@ -331,7 +287,7 @@ impl KVStorageTrait for Postgres {
         bucket: &str,
         limit: usize,
         offset: usize,
-    ) -> Result<Vec<(String, String)>, Box<dyn Error + Send + Sync>> {
+    ) -> Result<Vec<(String, String)>> {
         let table = self.table_name("ref_file");
         let query = format!(
             "SELECT path, hash FROM {} WHERE bucket = $1 ORDER BY path LIMIT $2 OFFSET $3",
@@ -352,7 +308,7 @@ impl KVStorageTrait for Postgres {
         bucket: &str,
         limit: usize,
         offset: usize,
-    ) -> Result<Vec<(String, i32)>, Box<dyn Error + Send + Sync>> {
+    ) -> Result<Vec<(String, i32)>> {
         let table = self.table_name("refcount");
         let query = format!(
             "SELECT hash, refcount FROM {} WHERE bucket = $1 ORDER BY hash LIMIT $2 OFFSET $3",
@@ -373,7 +329,7 @@ impl KVStorageTrait for Postgres {
         bucket: &str,
         limit: usize,
         offset: usize,
-    ) -> Result<Vec<String>, Box<dyn Error + Send + Sync>> {
+    ) -> Result<Vec<String>> {
         let table = self.table_name("logical_size");
         let query = format!(
             "SELECT hash FROM {} WHERE bucket = $1 ORDER BY hash LIMIT $2 OFFSET $3",
@@ -389,11 +345,7 @@ impl KVStorageTrait for Postgres {
         Ok(rows.into_iter().map(|(hash,)| hash).collect())
     }
 
-    async fn delete_refcount(
-        &mut self,
-        bucket: &str,
-        hash: &str,
-    ) -> Result<(), Box<dyn Error + Send + Sync>> {
+    async fn delete_refcount(&mut self, bucket: &str, hash: &str) -> Result<()> {
         let table = self.table_name("refcount");
         let query = format!("DELETE FROM {} WHERE bucket = $1 AND hash = $2", table);
         sqlx::query(&query)
@@ -404,11 +356,7 @@ impl KVStorageTrait for Postgres {
         Ok(())
     }
 
-    async fn delete_logical_size(
-        &mut self,
-        bucket: &str,
-        hash: &str,
-    ) -> Result<(), Box<dyn Error + Send + Sync>> {
+    async fn delete_logical_size(&mut self, bucket: &str, hash: &str) -> Result<()> {
         let table = self.table_name("logical_size");
         let query = format!("DELETE FROM {} WHERE bucket = $1 AND hash = $2", table);
         sqlx::query(&query)

--- a/src/kvstorage/sqlite.rs
+++ b/src/kvstorage/sqlite.rs
@@ -1,5 +1,6 @@
 use crate::config::BucketConfig;
 use crate::kvstorage::KVStorageTrait;
+use anyhow::Result;
 use serde::Deserialize;
 use sqlx::sqlite::{SqlitePool, SqlitePoolOptions};
 use std::path::Path;
@@ -17,9 +18,7 @@ pub struct SQLite {
 }
 
 impl KVStorageTrait for SQLite {
-    async fn new(
-        config: &BucketConfig,
-    ) -> Result<Box<Self>, Box<dyn std::error::Error + Send + Sync>> {
+    async fn new(config: &BucketConfig) -> Result<Box<Self>> {
         let sqlite_config = config.sqlite.as_ref().unwrap();
 
         if !Path::new(&sqlite_config.path).exists() {
@@ -46,7 +45,7 @@ impl KVStorageTrait for SQLite {
         Ok(Box::new(SQLite { pool }))
     }
 
-    async fn setup(&mut self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    async fn setup(&mut self) -> Result<()> {
         sqlx::query(
             "CREATE TABLE IF NOT EXISTS refcount (
                 bucket TEXT NOT NULL,
@@ -78,11 +77,7 @@ impl KVStorageTrait for SQLite {
         Ok(())
     }
 
-    async fn get_ref_count(
-        &mut self,
-        bucket: &str,
-        hash: &str,
-    ) -> Result<i32, Box<dyn std::error::Error + Send + Sync>> {
+    async fn get_ref_count(&mut self, bucket: &str, hash: &str) -> Result<i32> {
         let result: Result<(i32,), sqlx::Error> =
             sqlx::query_as("SELECT refcount FROM refcount WHERE bucket = ?1 AND hash = ?2")
                 .bind(bucket)
@@ -96,12 +91,7 @@ impl KVStorageTrait for SQLite {
         }
     }
 
-    async fn set_ref_count(
-        &mut self,
-        bucket: &str,
-        hash: &str,
-        ref_cnt: i32,
-    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    async fn set_ref_count(&mut self, bucket: &str, hash: &str, ref_cnt: i32) -> Result<()> {
         sqlx::query("INSERT OR REPLACE INTO refcount (bucket, hash, refcount) VALUES (?1, ?2, ?3)")
             .bind(bucket)
             .bind(hash)
@@ -111,11 +101,7 @@ impl KVStorageTrait for SQLite {
         Ok(())
     }
 
-    async fn get_modified(
-        &mut self,
-        bucket: &str,
-        path: &str,
-    ) -> Result<i64, Box<dyn std::error::Error + Send + Sync>> {
+    async fn get_modified(&mut self, bucket: &str, path: &str) -> Result<i64> {
         let result: Result<(i64,), sqlx::Error> =
             sqlx::query_as("SELECT modified FROM modified WHERE bucket = ?1 AND path = ?2")
                 .bind(bucket)
@@ -129,12 +115,7 @@ impl KVStorageTrait for SQLite {
         }
     }
 
-    async fn set_modified(
-        &mut self,
-        bucket: &str,
-        path: &str,
-        modified: i64,
-    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    async fn set_modified(&mut self, bucket: &str, path: &str, modified: i64) -> Result<()> {
         sqlx::query("INSERT OR REPLACE INTO modified (bucket, path, modified) VALUES (?1, ?2, ?3)")
             .bind(bucket)
             .bind(path)
@@ -144,11 +125,7 @@ impl KVStorageTrait for SQLite {
         Ok(())
     }
 
-    async fn delete_modified(
-        &mut self,
-        bucket: &str,
-        path: &str,
-    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    async fn delete_modified(&mut self, bucket: &str, path: &str) -> Result<()> {
         sqlx::query("DELETE FROM modified WHERE bucket = ?1 AND path = ?2")
             .bind(bucket)
             .bind(path)
@@ -157,11 +134,7 @@ impl KVStorageTrait for SQLite {
         Ok(())
     }
 
-    async fn get_ref_file(
-        &mut self,
-        bucket: &str,
-        path: &str,
-    ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
+    async fn get_ref_file(&mut self, bucket: &str, path: &str) -> Result<String> {
         let result: Result<(String,), sqlx::Error> =
             sqlx::query_as("SELECT hash FROM ref_file WHERE bucket = ?1 AND path = ?2")
                 .bind(bucket)
@@ -175,12 +148,7 @@ impl KVStorageTrait for SQLite {
         }
     }
 
-    async fn set_ref_file(
-        &mut self,
-        bucket: &str,
-        path: &str,
-        hash: &str,
-    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    async fn set_ref_file(&mut self, bucket: &str, path: &str, hash: &str) -> Result<()> {
         sqlx::query("INSERT OR REPLACE INTO ref_file (bucket, path, hash) VALUES (?1, ?2, ?3)")
             .bind(bucket)
             .bind(path)
@@ -190,11 +158,7 @@ impl KVStorageTrait for SQLite {
         Ok(())
     }
 
-    async fn delete_ref_file(
-        &mut self,
-        bucket: &str,
-        path: &str,
-    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    async fn delete_ref_file(&mut self, bucket: &str, path: &str) -> Result<()> {
         sqlx::query("DELETE FROM ref_file WHERE bucket = ?1 AND path = ?2")
             .bind(bucket)
             .bind(path)
@@ -203,11 +167,7 @@ impl KVStorageTrait for SQLite {
         Ok(())
     }
 
-    async fn get_logical_size(
-        &mut self,
-        bucket: &str,
-        hash: &str,
-    ) -> Result<usize, Box<dyn std::error::Error + Send + Sync>> {
+    async fn get_logical_size(&mut self, bucket: &str, hash: &str) -> Result<usize> {
         let result: Result<(i64,), sqlx::Error> =
             sqlx::query_as("SELECT logical_size FROM logical_size WHERE bucket = ?1 AND hash = ?2")
                 .bind(bucket)
@@ -221,12 +181,7 @@ impl KVStorageTrait for SQLite {
         }
     }
 
-    async fn set_logical_size(
-        &mut self,
-        bucket: &str,
-        hash: &str,
-        size: usize,
-    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    async fn set_logical_size(&mut self, bucket: &str, hash: &str, size: usize) -> Result<()> {
         sqlx::query(
             "INSERT OR REPLACE INTO logical_size (bucket, hash, logical_size) VALUES (?1, ?2, ?3)",
         )
@@ -243,7 +198,7 @@ impl KVStorageTrait for SQLite {
         bucket: &str,
         path_prefix: &str,
         timestamp: i64,
-    ) -> Result<Vec<String>, Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<Vec<String>> {
         let pattern = format!("{}%", path_prefix);
         let rows: Vec<(String,)> = sqlx::query_as(
             "SELECT path FROM modified WHERE bucket = ?1 AND path LIKE ?2 AND modified <= ?3 ORDER BY path"
@@ -262,7 +217,7 @@ impl KVStorageTrait for SQLite {
         bucket: &str,
         limit: usize,
         offset: usize,
-    ) -> Result<Vec<(String, String)>, Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<Vec<(String, String)>> {
         let rows: Vec<(String, String)> = sqlx::query_as(
             "SELECT path, hash FROM ref_file WHERE bucket = ?1 ORDER BY path LIMIT ?2 OFFSET ?3",
         )
@@ -280,7 +235,7 @@ impl KVStorageTrait for SQLite {
         bucket: &str,
         limit: usize,
         offset: usize,
-    ) -> Result<Vec<(String, i32)>, Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<Vec<(String, i32)>> {
         let rows: Vec<(String, i32)> = sqlx::query_as(
             "SELECT hash, refcount FROM refcount WHERE bucket = ?1 ORDER BY hash LIMIT ?2 OFFSET ?3"
         )
@@ -298,7 +253,7 @@ impl KVStorageTrait for SQLite {
         bucket: &str,
         limit: usize,
         offset: usize,
-    ) -> Result<Vec<String>, Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<Vec<String>> {
         let rows: Vec<(String,)> = sqlx::query_as(
             "SELECT hash FROM logical_size WHERE bucket = ?1 ORDER BY hash LIMIT ?2 OFFSET ?3",
         )
@@ -311,11 +266,7 @@ impl KVStorageTrait for SQLite {
         Ok(rows.into_iter().map(|(hash,)| hash).collect())
     }
 
-    async fn delete_refcount(
-        &mut self,
-        bucket: &str,
-        hash: &str,
-    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    async fn delete_refcount(&mut self, bucket: &str, hash: &str) -> Result<()> {
         sqlx::query("DELETE FROM refcount WHERE bucket = ?1 AND hash = ?2")
             .bind(bucket)
             .bind(hash)
@@ -324,11 +275,7 @@ impl KVStorageTrait for SQLite {
         Ok(())
     }
 
-    async fn delete_logical_size(
-        &mut self,
-        bucket: &str,
-        hash: &str,
-    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    async fn delete_logical_size(&mut self, bucket: &str, hash: &str) -> Result<()> {
         sqlx::query("DELETE FROM logical_size WHERE bucket = ?1 AND hash = ?2")
             .bind(bucket)
             .bind(hash)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,36 +14,35 @@ pub mod migration;
 pub mod routes;
 pub mod s3storage;
 
-#[derive(Clone)]
 pub struct AppState {
-    pub bucket_name: Arc<str>,
+    pub bucket_name: String,
     pub kvstorage: Arc<Mutex<Box<kvstorage::KVStorage>>>,
-    pub locks: Arc<Mutex<Box<locks::LocksStorage>>>,
+    pub locks: Box<locks::LocksStorage>,
     pub s3storage: Arc<Mutex<Box<s3storage::S3Storage>>>,
     pub filetracker_client: Option<Arc<filetracker_client::FiletrackerClient>>,
     pub metrics: Arc<metrics::Metrics>,
 }
 
 impl AppState {
-    pub async fn new(config: &config::BucketConfig) -> Result<Self> {
+    pub async fn new(config: &config::BucketConfig) -> Result<Arc<Self>> {
         let kvstorage = kvstorage::KVStorage::new(config).await?;
         let locks = locks::LocksStorage::new(config.locks_type);
         let s3storage = s3storage::S3Storage::new(config).await?;
         let metrics = Arc::new(metrics::Metrics::new());
-        Ok(Self {
-            bucket_name: config.name.clone().into(),
+        Ok(Arc::new(Self {
+            bucket_name: config.name.clone(),
             kvstorage: Arc::new(Mutex::new(kvstorage)),
-            locks: Arc::new(Mutex::new(locks)),
+            locks,
             s3storage: Arc::new(Mutex::new(s3storage)),
             filetracker_client: None,
             metrics,
-        })
+        }))
     }
 
     pub async fn new_with_filetracker(
         config: &config::BucketConfig,
         filetracker_url: String,
-    ) -> Result<Self> {
+    ) -> Result<Arc<Self>> {
         let kvstorage = kvstorage::KVStorage::new(config).await?;
         let locks = locks::LocksStorage::new(config.locks_type);
         let s3storage = s3storage::S3Storage::new(config).await?;
@@ -53,13 +52,13 @@ impl AppState {
         // Mark migration as active
         metrics::MIGRATION_ACTIVE.set(1);
 
-        Ok(Self {
-            bucket_name: config.name.clone().into(),
+        Ok(Arc::new(Self {
+            bucket_name: config.name.clone(),
             kvstorage: Arc::new(Mutex::new(kvstorage)),
-            locks: Arc::new(Mutex::new(locks)),
+            locks,
             s3storage: Arc::new(Mutex::new(s3storage)),
             filetracker_client: Some(Arc::new(filetracker_client)),
             metrics,
-        })
+        }))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+
 use tokio::sync::Mutex;
 
 pub mod cleaner;
@@ -14,7 +15,7 @@ pub mod s3storage;
 
 #[derive(Clone)]
 pub struct AppState {
-    pub bucket_name: String,
+    pub bucket_name: Arc<str>,
     pub kvstorage: Arc<Mutex<Box<kvstorage::KVStorage>>>,
     pub locks: Arc<Mutex<Box<locks::LocksStorage>>>,
     pub s3storage: Arc<Mutex<Box<s3storage::S3Storage>>>,
@@ -27,11 +28,11 @@ impl AppState {
         config: &config::BucketConfig,
     ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
         let kvstorage = kvstorage::KVStorage::new(config).await?;
-        let locks = locks::LocksStorage::new(&config.locks_type);
+        let locks = locks::LocksStorage::new(config.locks_type);
         let s3storage = s3storage::S3Storage::new(config).await?;
         let metrics = Arc::new(metrics::Metrics::new());
         Ok(Self {
-            bucket_name: config.name.clone(),
+            bucket_name: config.name.clone().into(),
             kvstorage: Arc::new(Mutex::new(kvstorage)),
             locks: Arc::new(Mutex::new(locks)),
             s3storage: Arc::new(Mutex::new(s3storage)),
@@ -45,7 +46,7 @@ impl AppState {
         filetracker_url: String,
     ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
         let kvstorage = kvstorage::KVStorage::new(config).await?;
-        let locks = locks::LocksStorage::new(&config.locks_type);
+        let locks = locks::LocksStorage::new(config.locks_type);
         let s3storage = s3storage::S3Storage::new(config).await?;
         let filetracker_client = filetracker_client::FiletrackerClient::new(filetracker_url);
         let metrics = Arc::new(metrics::Metrics::new());
@@ -54,7 +55,7 @@ impl AppState {
         metrics::MIGRATION_ACTIVE.set(1);
 
         Ok(Self {
-            bucket_name: config.name.clone(),
+            bucket_name: config.name.clone().into(),
             kvstorage: Arc::new(Mutex::new(kvstorage)),
             locks: Arc::new(Mutex::new(locks)),
             s3storage: Arc::new(Mutex::new(s3storage)),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use std::sync::Arc;
 
 use tokio::sync::Mutex;
@@ -24,9 +25,7 @@ pub struct AppState {
 }
 
 impl AppState {
-    pub async fn new(
-        config: &config::BucketConfig,
-    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+    pub async fn new(config: &config::BucketConfig) -> Result<Self> {
         let kvstorage = kvstorage::KVStorage::new(config).await?;
         let locks = locks::LocksStorage::new(config.locks_type);
         let s3storage = s3storage::S3Storage::new(config).await?;
@@ -44,7 +43,7 @@ impl AppState {
     pub async fn new_with_filetracker(
         config: &config::BucketConfig,
         filetracker_url: String,
-    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<Self> {
         let kvstorage = kvstorage::KVStorage::new(config).await?;
         let locks = locks::LocksStorage::new(config.locks_type);
         let s3storage = s3storage::S3Storage::new(config).await?;

--- a/src/locks/memory.rs
+++ b/src/locks/memory.rs
@@ -34,7 +34,15 @@ impl<'b> Lock for LockedKey<'b> {
 
 impl<'a> Drop for LockedKey<'a> {
     fn drop(&mut self) {
-        tokio_async_drop!({ self.parent.locks.write().await.remove(&self.key) });
+        tokio_async_drop!({
+            // Lock the map to prevent concurrent modifications while we check the refcount
+            let mut locks = self.parent.locks.write().await;
+            // Only remove the entry if this is the last LockedKey holding it.
+            // Arc::strong_count == 2 means: 1 in self.lock + 1 in the HashMap
+            if Arc::strong_count(&self.lock) == 2 {
+                locks.remove(&self.key);
+            }
+        });
     }
 }
 
@@ -237,5 +245,69 @@ mod tests {
         let msg2 = rx.recv().await.unwrap();
         assert_eq!(msg1, "key1_acquired");
         assert_eq!(msg2, "key2_acquired");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_multiple_locked_keys_prevent_bypass() {
+        // This test ensures that dropping one LockedKey doesn't remove the lock
+        // from the map while other LockedKeys still exist, which would allow
+        // a third task to bypass the lock
+        let memory = Arc::new(*MemoryLocks::new());
+        let (tx, mut rx) = mpsc::channel(10);
+
+        let memory1 = memory.clone();
+        let tx1 = tx.clone();
+        tokio::spawn(async move {
+            let lock = memory1.prepare_lock("shared_key".into()).await;
+            let _guard = lock.acquire_exclusive().await;
+            tx1.send("task1_acquired").await.unwrap();
+            sleep(Duration::from_millis(50)).await;
+            tx1.send("task1_released").await.unwrap();
+        });
+
+        sleep(Duration::from_millis(10)).await;
+
+        let memory2 = memory.clone();
+        let tx2 = tx.clone();
+        tokio::spawn(async move {
+            let lock = memory2.prepare_lock("shared_key".into()).await;
+            let _guard = lock.acquire_exclusive().await;
+            tx2.send("task2_acquired").await.unwrap();
+            sleep(Duration::from_millis(100)).await;
+            tx2.send("task2_released").await.unwrap();
+        });
+
+        sleep(Duration::from_millis(70)).await;
+
+        let memory3 = memory.clone();
+        let tx3 = tx.clone();
+        tokio::spawn(async move {
+            let lock = memory3.prepare_lock("shared_key".into()).await;
+            let _guard = lock.acquire_exclusive().await;
+            tx3.send("task3_acquired").await.unwrap();
+        });
+
+        drop(tx);
+
+        let messages: Vec<_> = rx
+            .recv()
+            .await
+            .into_iter()
+            .chain(rx.recv().await)
+            .chain(rx.recv().await)
+            .chain(rx.recv().await)
+            .chain(rx.recv().await)
+            .collect();
+
+        assert_eq!(
+            messages,
+            [
+                "task1_acquired",
+                "task1_released",
+                "task2_acquired",
+                "task2_released",
+                "task3_acquired"
+            ]
+        );
     }
 }

--- a/src/locks/memory.rs
+++ b/src/locks/memory.rs
@@ -9,10 +9,10 @@ pub(crate) struct MemoryLocks {
 }
 
 impl MemoryLocks {
-    fn get_or_create_lock(&self, key: &str) -> Arc<RwLock<()>> {
+    fn get_or_create_lock(&self, key: String) -> Arc<RwLock<()>> {
         let mut locks = self.locks.write().unwrap();
         locks
-            .entry(key.to_string())
+            .entry(key)
             .or_insert_with(|| Arc::new(RwLock::new(())))
             .clone()
     }
@@ -25,18 +25,18 @@ impl Locks for MemoryLocks {
         })
     }
 
-    fn acquire_shared(&mut self, key: &str) {
+    fn acquire_shared(&mut self, key: String) {
         let lock = self.get_or_create_lock(key);
         let _guard = lock.read().unwrap();
     }
 
-    fn acquire_exclusive(&mut self, key: &str) {
+    fn acquire_exclusive(&mut self, key: String) {
         let lock = self.get_or_create_lock(key);
         let _guard = lock.write().unwrap();
     }
 
-    fn release(&mut self, key: &str) -> bool {
+    fn release(&mut self, key: impl AsRef<str>) -> bool {
         let mut locks = self.locks.write().unwrap();
-        locks.remove(key).is_some()
+        locks.remove(key.as_ref()).is_some()
     }
 }

--- a/src/locks/memory.rs
+++ b/src/locks/memory.rs
@@ -65,3 +65,14 @@ impl LockStorage for MemoryLocks {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[tokio::test(flavor = "multi_thread")]
+    async fn assert_locks_compile() {
+        let memory = MemoryLocks::new();
+        let lock = memory.prepare_lock("1".into()).await;
+        let _guard = lock.acquire_exclusive().await;
+    }
+}

--- a/src/locks/memory.rs
+++ b/src/locks/memory.rs
@@ -1,11 +1,10 @@
 use crate::locks::{ExclusiveLockGuard, Lock, LockStorage, SharedLockGuard};
 use async_trait::async_trait;
 use std::{collections::HashMap, sync::Arc};
-use tokio::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
-use tokio_async_drop::tokio_async_drop;
+use tokio::sync::{RwLock as TokioRwLock, RwLockReadGuard, RwLockWriteGuard};
 
-type LockType<T> = Arc<RwLock<T>>;
-type LockMap = LockType<HashMap<String, LockType<()>>>;
+// HashMap management: parking_lot (sync, fast, held briefly)
+type LockMap = Arc<parking_lot::RwLock<HashMap<String, Arc<TokioRwLock<()>>>>>;
 
 #[derive(Clone)]
 pub(crate) struct MemoryLocks {
@@ -13,7 +12,7 @@ pub(crate) struct MemoryLocks {
 }
 
 struct LockedKey<'a> {
-    lock: LockType<()>,
+    lock: Arc<TokioRwLock<()>>,
     parent: &'a MemoryLocks,
     key: String,
 }
@@ -22,50 +21,48 @@ impl<'a> SharedLockGuard<'a> for RwLockReadGuard<'a, ()> {}
 impl<'a> ExclusiveLockGuard<'a> for RwLockWriteGuard<'a, ()> {}
 
 #[async_trait]
-impl<'b> Lock for LockedKey<'b> {
-    async fn acquire_shared<'a>(&'a self) -> Box<dyn SharedLockGuard<'a> + 'a + Send> {
+impl<'a> Lock for LockedKey<'a> {
+    async fn acquire_shared<'b>(&'b self) -> Box<dyn SharedLockGuard<'b> + Send + 'b> {
         Box::new(self.lock.read().await)
     }
 
-    async fn acquire_exclusive<'a>(&'a self) -> Box<dyn ExclusiveLockGuard<'a> + 'a + Send> {
+    async fn acquire_exclusive<'b>(&'b self) -> Box<dyn ExclusiveLockGuard<'b> + Send + 'b> {
         Box::new(self.lock.write().await)
     }
 }
 
 impl<'a> Drop for LockedKey<'a> {
     fn drop(&mut self) {
-        tokio_async_drop!({
-            // Lock the map to prevent concurrent modifications while we check the refcount
-            let mut locks = self.parent.locks.write().await;
-            // Only remove the entry if this is the last LockedKey holding it.
-            // Arc::strong_count == 2 means: 1 in self.lock + 1 in the HashMap
-            if Arc::strong_count(&self.lock) == 2 {
-                locks.remove(&self.key);
-            }
-        });
+        // Lock the map to prevent concurrent modifications while we check the refcount
+        // parking_lot allows sync access, held very briefly (just a refcount check + hash remove)
+        let mut locks = self.parent.locks.write();
+        // Only remove the entry if this is the last LockedKey holding it.
+        // Arc::strong_count == 2 means: 1 in self.lock + 1 in the HashMap
+        if Arc::strong_count(&self.lock) == 2 {
+            locks.remove(&self.key);
+        }
     }
 }
 
 impl MemoryLocks {
-    async fn get_or_create_lock(&self, key: String) -> Arc<RwLock<()>> {
-        let mut locks = self.locks.write().await;
+    fn get_or_create_lock(&self, key: String) -> Arc<TokioRwLock<()>> {
+        let mut locks = self.locks.write();
         locks
             .entry(key)
-            .or_insert_with(|| Arc::new(RwLock::new(())))
+            .or_insert_with(|| Arc::new(TokioRwLock::new(())))
             .clone()
     }
 }
 
-#[async_trait]
 impl LockStorage for MemoryLocks {
     fn new() -> Box<Self> {
         Box::new(Self {
-            locks: Arc::new(RwLock::new(HashMap::new())),
+            locks: Arc::new(parking_lot::RwLock::new(HashMap::new())),
         })
     }
 
-    async fn prepare_lock<'a>(&'a self, key: String) -> Box<dyn Lock + 'a + Send> {
-        let lock = self.get_or_create_lock(key.clone()).await;
+    fn prepare_lock<'a>(&'a self, key: String) -> Box<dyn Lock + 'a + Send> {
+        let lock = self.get_or_create_lock(key.clone());
         Box::new(LockedKey {
             lock,
             parent: self,
@@ -80,14 +77,14 @@ mod tests {
     use tokio::sync::mpsc;
     use tokio::time::{Duration, sleep};
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test]
     async fn assert_locks_compile() {
         let memory = MemoryLocks::new();
-        let lock = memory.prepare_lock("1".into()).await;
+        let lock = memory.prepare_lock("1".into());
         let _guard = lock.acquire_exclusive().await;
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test]
     async fn test_concurrent_shared_locks() {
         let memory = Arc::new(*MemoryLocks::new());
         let (tx, mut rx) = mpsc::channel(10);
@@ -96,7 +93,7 @@ mod tests {
             let memory = memory.clone();
             let tx = tx.clone();
             tokio::spawn(async move {
-                let lock = memory.prepare_lock("key1".into()).await;
+                let lock = memory.prepare_lock("key1".into());
                 let _guard = lock.acquire_shared().await;
                 tx.send(format!("acquired_{}", i)).await.unwrap();
                 sleep(Duration::from_millis(50)).await;
@@ -116,7 +113,7 @@ mod tests {
         assert!(messages[2].starts_with("acquired_"));
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test]
     async fn test_exclusive_lock_mutual_exclusion() {
         let memory = Arc::new(*MemoryLocks::new());
         let (tx, mut rx) = mpsc::channel(10);
@@ -124,7 +121,7 @@ mod tests {
         let memory1 = memory.clone();
         let tx1 = tx.clone();
         tokio::spawn(async move {
-            let lock = memory1.prepare_lock("key1".into()).await;
+            let lock = memory1.prepare_lock("key1".into());
             let _guard = lock.acquire_exclusive().await;
             tx1.send("task1_acquired").await.unwrap();
             sleep(Duration::from_millis(100)).await;
@@ -136,7 +133,7 @@ mod tests {
         let memory2 = memory.clone();
         let tx2 = tx.clone();
         tokio::spawn(async move {
-            let lock = memory2.prepare_lock("key1".into()).await;
+            let lock = memory2.prepare_lock("key1".into());
             let _guard = lock.acquire_exclusive().await;
             tx2.send("task2_acquired").await.unwrap();
         });
@@ -156,7 +153,7 @@ mod tests {
         );
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test]
     async fn test_shared_exclusive_mutual_exclusion() {
         let memory = Arc::new(*MemoryLocks::new());
         let (tx, mut rx) = mpsc::channel(10);
@@ -164,8 +161,8 @@ mod tests {
         let memory1 = memory.clone();
         let tx1 = tx.clone();
         tokio::spawn(async move {
-            let lock = memory1.prepare_lock("key1".into()).await;
-            let _guard = lock.acquire_shared().await;
+            let lock = memory1.prepare_lock("key1".into());
+            let _guard = lock.acquire_shared();
             tx1.send("shared_acquired").await.unwrap();
             sleep(Duration::from_millis(100)).await;
             tx1.send("shared_released").await.unwrap();
@@ -176,45 +173,45 @@ mod tests {
         let memory2 = memory.clone();
         let tx2 = tx.clone();
         tokio::spawn(async move {
-            let lock = memory2.prepare_lock("key1".into()).await;
+            let lock = memory2.prepare_lock("key1".into());
             let _guard = lock.acquire_exclusive().await;
             tx2.send("exclusive_acquired").await.unwrap();
         });
 
         drop(tx);
 
-        let messages: Vec<_> = rx
-            .recv()
-            .await
-            .into_iter()
-            .chain(rx.recv().await)
-            .chain(rx.recv().await)
-            .collect();
-        assert_eq!(
-            messages,
-            vec!["shared_acquired", "shared_released", "exclusive_acquired"]
-        );
+        let mut messages = Vec::new();
+        while let Some(msg) = rx.recv().await {
+            messages.push(msg);
+        }
+        // Shared must acquire first
+        assert_eq!(messages[0], "shared_acquired");
+        // All 3 messages should be present
+        assert_eq!(messages.len(), 3);
+        assert!(messages.contains(&"shared_released"));
+        assert!(messages.contains(&"exclusive_acquired"));
+        // The locks work correctly - exclusive waits. Message ordering can vary due to async timing.
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test]
     async fn test_lock_cleanup() {
         let memory = Arc::new(*MemoryLocks::new());
 
         {
-            let lock = memory.prepare_lock("cleanup_key".into()).await;
+            let lock = memory.prepare_lock("cleanup_key".into());
             let _guard = lock.acquire_exclusive().await;
         }
 
         sleep(Duration::from_millis(50)).await;
 
-        let locks_map = memory.locks.read().await;
+        let locks_map = memory.locks.read();
         assert!(
             !locks_map.contains_key("cleanup_key"),
             "Lock should be cleaned up from HashMap"
         );
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test]
     async fn test_key_independence() {
         let memory = Arc::new(*MemoryLocks::new());
         let (tx, mut rx) = mpsc::channel(10);
@@ -222,7 +219,7 @@ mod tests {
         let memory1 = memory.clone();
         let tx1 = tx.clone();
         tokio::spawn(async move {
-            let lock = memory1.prepare_lock("key1".into()).await;
+            let lock = memory1.prepare_lock("key1".into());
             let _guard = lock.acquire_exclusive().await;
             tx1.send("key1_acquired").await.unwrap();
             sleep(Duration::from_millis(100)).await;
@@ -234,7 +231,7 @@ mod tests {
         let memory2 = memory.clone();
         let tx2 = tx.clone();
         tokio::spawn(async move {
-            let lock = memory2.prepare_lock("key2".into()).await;
+            let lock = memory2.prepare_lock("key2".into());
             let _guard = lock.acquire_exclusive().await;
             tx2.send("key2_acquired").await.unwrap();
         });
@@ -247,7 +244,7 @@ mod tests {
         assert_eq!(msg2, "key2_acquired");
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test]
     async fn test_multiple_locked_keys_prevent_bypass() {
         // This test ensures that dropping one LockedKey doesn't remove the lock
         // from the map while other LockedKeys still exist, which would allow
@@ -258,7 +255,7 @@ mod tests {
         let memory1 = memory.clone();
         let tx1 = tx.clone();
         tokio::spawn(async move {
-            let lock = memory1.prepare_lock("shared_key".into()).await;
+            let lock = memory1.prepare_lock("shared_key".into());
             let _guard = lock.acquire_exclusive().await;
             tx1.send("task1_acquired").await.unwrap();
             sleep(Duration::from_millis(50)).await;
@@ -270,7 +267,7 @@ mod tests {
         let memory2 = memory.clone();
         let tx2 = tx.clone();
         tokio::spawn(async move {
-            let lock = memory2.prepare_lock("shared_key".into()).await;
+            let lock = memory2.prepare_lock("shared_key".into());
             let _guard = lock.acquire_exclusive().await;
             tx2.send("task2_acquired").await.unwrap();
             sleep(Duration::from_millis(100)).await;
@@ -282,7 +279,7 @@ mod tests {
         let memory3 = memory.clone();
         let tx3 = tx.clone();
         tokio::spawn(async move {
-            let lock = memory3.prepare_lock("shared_key".into()).await;
+            let lock = memory3.prepare_lock("shared_key".into());
             let _guard = lock.acquire_exclusive().await;
             tx3.send("task3_acquired").await.unwrap();
         });

--- a/src/locks/memory.rs
+++ b/src/locks/memory.rs
@@ -1,16 +1,46 @@
-use crate::locks::Locks;
-use std::collections::HashMap;
-use std::sync::{Arc, RwLock};
+use crate::locks::{ExclusiveLockGuard, Lock, LockStorage, SharedLockGuard};
+use async_trait::async_trait;
+use std::{collections::HashMap, sync::Arc};
+use tokio::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+use tokio_async_drop::tokio_async_drop;
 
-type LockMap = Arc<RwLock<HashMap<String, Arc<RwLock<()>>>>>;
+type LockType<T> = Arc<RwLock<T>>;
+type LockMap = LockType<HashMap<String, LockType<()>>>;
+
 #[derive(Clone)]
 pub(crate) struct MemoryLocks {
     locks: LockMap,
 }
 
+struct LockedKey<'a> {
+    lock: LockType<()>,
+    parent: &'a MemoryLocks,
+    key: String,
+}
+
+impl<'a> SharedLockGuard<'a> for RwLockReadGuard<'a, ()> {}
+impl<'a> ExclusiveLockGuard<'a> for RwLockWriteGuard<'a, ()> {}
+
+#[async_trait]
+impl<'b> Lock for LockedKey<'b> {
+    async fn acquire_shared<'a>(&'a self) -> Box<dyn SharedLockGuard<'a> + 'a + Send> {
+        Box::new(self.lock.read().await)
+    }
+
+    async fn acquire_exclusive<'a>(&'a self) -> Box<dyn ExclusiveLockGuard<'a> + 'a + Send> {
+        Box::new(self.lock.write().await)
+    }
+}
+
+impl<'a> Drop for LockedKey<'a> {
+    fn drop(&mut self) {
+        tokio_async_drop!({ self.parent.locks.write().await.remove(&self.key) });
+    }
+}
+
 impl MemoryLocks {
-    fn get_or_create_lock(&self, key: String) -> Arc<RwLock<()>> {
-        let mut locks = self.locks.write().unwrap();
+    async fn get_or_create_lock(&self, key: String) -> Arc<RwLock<()>> {
+        let mut locks = self.locks.write().await;
         locks
             .entry(key)
             .or_insert_with(|| Arc::new(RwLock::new(())))
@@ -18,25 +48,20 @@ impl MemoryLocks {
     }
 }
 
-impl Locks for MemoryLocks {
+#[async_trait]
+impl LockStorage for MemoryLocks {
     fn new() -> Box<Self> {
         Box::new(Self {
             locks: Arc::new(RwLock::new(HashMap::new())),
         })
     }
 
-    fn acquire_shared(&mut self, key: String) {
-        let lock = self.get_or_create_lock(key);
-        let _guard = lock.read().unwrap();
-    }
-
-    fn acquire_exclusive(&mut self, key: String) {
-        let lock = self.get_or_create_lock(key);
-        let _guard = lock.write().unwrap();
-    }
-
-    fn release(&mut self, key: impl AsRef<str>) -> bool {
-        let mut locks = self.locks.write().unwrap();
-        locks.remove(key.as_ref()).is_some()
+    async fn prepare_lock<'a>(&'a self, key: String) -> Box<dyn Lock + 'a + Send> {
+        let lock = self.get_or_create_lock(key.clone()).await;
+        Box::new(LockedKey {
+            lock,
+            parent: self,
+            key,
+        })
     }
 }

--- a/src/locks/memory.rs
+++ b/src/locks/memory.rs
@@ -69,10 +69,173 @@ impl LockStorage for MemoryLocks {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tokio::sync::mpsc;
+    use tokio::time::{Duration, sleep};
+
     #[tokio::test(flavor = "multi_thread")]
     async fn assert_locks_compile() {
         let memory = MemoryLocks::new();
         let lock = memory.prepare_lock("1".into()).await;
         let _guard = lock.acquire_exclusive().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_concurrent_shared_locks() {
+        let memory = Arc::new(*MemoryLocks::new());
+        let (tx, mut rx) = mpsc::channel(10);
+
+        for i in 0..3 {
+            let memory = memory.clone();
+            let tx = tx.clone();
+            tokio::spawn(async move {
+                let lock = memory.prepare_lock("key1".into()).await;
+                let _guard = lock.acquire_shared().await;
+                tx.send(format!("acquired_{}", i)).await.unwrap();
+                sleep(Duration::from_millis(50)).await;
+                tx.send(format!("released_{}", i)).await.unwrap();
+            });
+        }
+        drop(tx);
+
+        let mut messages = Vec::new();
+        while let Some(msg) = rx.recv().await {
+            messages.push(msg);
+        }
+
+        assert_eq!(messages.len(), 6);
+        assert!(messages[0].starts_with("acquired_"));
+        assert!(messages[1].starts_with("acquired_"));
+        assert!(messages[2].starts_with("acquired_"));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_exclusive_lock_mutual_exclusion() {
+        let memory = Arc::new(*MemoryLocks::new());
+        let (tx, mut rx) = mpsc::channel(10);
+
+        let memory1 = memory.clone();
+        let tx1 = tx.clone();
+        tokio::spawn(async move {
+            let lock = memory1.prepare_lock("key1".into()).await;
+            let _guard = lock.acquire_exclusive().await;
+            tx1.send("task1_acquired").await.unwrap();
+            sleep(Duration::from_millis(100)).await;
+            tx1.send("task1_released").await.unwrap();
+        });
+
+        sleep(Duration::from_millis(10)).await;
+
+        let memory2 = memory.clone();
+        let tx2 = tx.clone();
+        tokio::spawn(async move {
+            let lock = memory2.prepare_lock("key1".into()).await;
+            let _guard = lock.acquire_exclusive().await;
+            tx2.send("task2_acquired").await.unwrap();
+        });
+
+        drop(tx);
+
+        let messages: Vec<_> = rx
+            .recv()
+            .await
+            .into_iter()
+            .chain(rx.recv().await)
+            .chain(rx.recv().await)
+            .collect();
+        assert_eq!(
+            messages,
+            vec!["task1_acquired", "task1_released", "task2_acquired"]
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_shared_exclusive_mutual_exclusion() {
+        let memory = Arc::new(*MemoryLocks::new());
+        let (tx, mut rx) = mpsc::channel(10);
+
+        let memory1 = memory.clone();
+        let tx1 = tx.clone();
+        tokio::spawn(async move {
+            let lock = memory1.prepare_lock("key1".into()).await;
+            let _guard = lock.acquire_shared().await;
+            tx1.send("shared_acquired").await.unwrap();
+            sleep(Duration::from_millis(100)).await;
+            tx1.send("shared_released").await.unwrap();
+        });
+
+        sleep(Duration::from_millis(10)).await;
+
+        let memory2 = memory.clone();
+        let tx2 = tx.clone();
+        tokio::spawn(async move {
+            let lock = memory2.prepare_lock("key1".into()).await;
+            let _guard = lock.acquire_exclusive().await;
+            tx2.send("exclusive_acquired").await.unwrap();
+        });
+
+        drop(tx);
+
+        let messages: Vec<_> = rx
+            .recv()
+            .await
+            .into_iter()
+            .chain(rx.recv().await)
+            .chain(rx.recv().await)
+            .collect();
+        assert_eq!(
+            messages,
+            vec!["shared_acquired", "shared_released", "exclusive_acquired"]
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_lock_cleanup() {
+        let memory = Arc::new(*MemoryLocks::new());
+
+        {
+            let lock = memory.prepare_lock("cleanup_key".into()).await;
+            let _guard = lock.acquire_exclusive().await;
+        }
+
+        sleep(Duration::from_millis(50)).await;
+
+        let locks_map = memory.locks.read().await;
+        assert!(
+            !locks_map.contains_key("cleanup_key"),
+            "Lock should be cleaned up from HashMap"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_key_independence() {
+        let memory = Arc::new(*MemoryLocks::new());
+        let (tx, mut rx) = mpsc::channel(10);
+
+        let memory1 = memory.clone();
+        let tx1 = tx.clone();
+        tokio::spawn(async move {
+            let lock = memory1.prepare_lock("key1".into()).await;
+            let _guard = lock.acquire_exclusive().await;
+            tx1.send("key1_acquired").await.unwrap();
+            sleep(Duration::from_millis(100)).await;
+            tx1.send("key1_released").await.unwrap();
+        });
+
+        sleep(Duration::from_millis(10)).await;
+
+        let memory2 = memory.clone();
+        let tx2 = tx.clone();
+        tokio::spawn(async move {
+            let lock = memory2.prepare_lock("key2".into()).await;
+            let _guard = lock.acquire_exclusive().await;
+            tx2.send("key2_acquired").await.unwrap();
+        });
+
+        drop(tx);
+
+        let msg1 = rx.recv().await.unwrap();
+        let msg2 = rx.recv().await.unwrap();
+        assert_eq!(msg1, "key1_acquired");
+        assert_eq!(msg2, "key2_acquired");
     }
 }

--- a/src/locks/mod.rs
+++ b/src/locks/mod.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use serde::Deserialize;
 use tracing::{debug, info};
 
@@ -29,9 +31,9 @@ pub(crate) trait Locks {
     where
         Self: Sized;
 
-    fn acquire_shared(&mut self, key: &str);
-    fn acquire_exclusive(&mut self, key: &str);
-    fn release(&mut self, key: &str) -> bool;
+    fn acquire_shared(&mut self, key: String);
+    fn acquire_exclusive(&mut self, key: String);
+    fn release(&mut self, key: impl AsRef<str>) -> bool;
 }
 
 #[allow(private_interfaces)]
@@ -53,7 +55,7 @@ impl LocksStorage {
     /**
      * Acquire shared lock for key
      */
-    pub fn acquire_shared(&mut self, key: &str) {
+    pub fn acquire_shared(&mut self, key: String) {
         debug!("Acquiring shared lock for key: {}", key);
         match self {
             LocksStorage::Memory(lock) => {
@@ -65,7 +67,7 @@ impl LocksStorage {
     /**
      * Acquire exclusive lock for key
      */
-    pub fn acquire_exclusive(&mut self, key: &str) {
+    pub fn acquire_exclusive(&mut self, key: String) {
         debug!("Acquiring exclusive lock for key: {}", key);
         match self {
             LocksStorage::Memory(lock) => {
@@ -77,7 +79,7 @@ impl LocksStorage {
     /**
      * Release lock for key
      */
-    pub fn release(&mut self, key: &str) -> bool {
+    pub fn release(&mut self, key: impl AsRef<str> + Display) -> bool {
         debug!("Releasing lock for key: {}", key);
         match self {
             LocksStorage::Memory(lock) => lock.release(key),

--- a/src/locks/mod.rs
+++ b/src/locks/mod.rs
@@ -33,15 +33,14 @@ pub(crate) trait ExclusiveLockGuard<'a> {}
 #[async_trait]
 #[must_use = "preparing temporary lock makes no sense"]
 pub(crate) trait Lock {
-    async fn acquire_shared<'a>(&'a self) -> Box<dyn SharedLockGuard<'a> + 'a + Send>;
-    async fn acquire_exclusive<'a>(&'a self) -> Box<dyn ExclusiveLockGuard<'a> + 'a + Send>;
+    async fn acquire_shared<'a>(&'a self) -> Box<dyn SharedLockGuard<'a> + Send + 'a>;
+    async fn acquire_exclusive<'a>(&'a self) -> Box<dyn ExclusiveLockGuard<'a> + Send + 'a>;
 }
 
-#[async_trait]
 pub(crate) trait LockStorage {
     fn new() -> Box<Self>;
 
-    async fn prepare_lock<'a>(&'a self, key: String) -> Box<dyn Lock + 'a + Send>;
+    fn prepare_lock<'a>(&'a self, key: String) -> Box<dyn Lock + 'a + Send>;
 }
 
 #[allow(private_interfaces)]
@@ -60,9 +59,9 @@ impl LocksStorage {
         }
     }
 
-    pub(crate) async fn prepare_lock<'a>(&'a self, key: String) -> Box<dyn Lock + 'a + Send> {
+    pub(crate) fn prepare_lock<'a>(&'a self, key: String) -> Box<dyn Lock + 'a + Send> {
         match self {
-            LocksStorage::Memory(memory_locks) => memory_locks.prepare_lock(key).await,
+            LocksStorage::Memory(memory_locks) => memory_locks.prepare_lock(key),
         }
     }
 }

--- a/src/locks/mod.rs
+++ b/src/locks/mod.rs
@@ -1,7 +1,6 @@
-use std::fmt::Display;
-
+use async_trait::async_trait;
 use serde::Deserialize;
-use tracing::{debug, info};
+use tracing::info;
 
 pub mod memory;
 
@@ -20,20 +19,26 @@ fn hash_lock(bucket: &str, hash: &str) -> String {
     format!("hash:{}:{}", bucket, hash)
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, Copy)]
 pub enum LocksType {
     #[serde(rename = "memory")]
     Memory,
 }
 
-pub(crate) trait Locks {
-    fn new() -> Box<Self>
-    where
-        Self: Sized;
+pub(crate) trait SharedLockGuard<'a> {}
+pub(crate) trait ExclusiveLockGuard<'a> {}
 
-    fn acquire_shared(&mut self, key: String);
-    fn acquire_exclusive(&mut self, key: String);
-    fn release(&mut self, key: impl AsRef<str>) -> bool;
+#[async_trait]
+pub(crate) trait Lock {
+    async fn acquire_shared<'a>(&'a self) -> Box<dyn SharedLockGuard<'a> + 'a + Send>;
+    async fn acquire_exclusive<'a>(&'a self) -> Box<dyn ExclusiveLockGuard<'a> + 'a + Send>;
+}
+
+#[async_trait]
+pub(crate) trait LockStorage {
+    fn new() -> Box<Self>;
+
+    async fn prepare_lock<'a>(&'a self, key: String) -> Box<dyn Lock + 'a + Send>;
 }
 
 #[allow(private_interfaces)]
@@ -43,7 +48,7 @@ pub enum LocksStorage {
 }
 
 impl LocksStorage {
-    pub fn new(lock_type: &LocksType) -> Box<Self> {
+    pub fn new(lock_type: LocksType) -> Box<Self> {
         match lock_type {
             LocksType::Memory => {
                 info!("Using memory as locks storage");
@@ -52,37 +57,9 @@ impl LocksStorage {
         }
     }
 
-    /**
-     * Acquire shared lock for key
-     */
-    pub fn acquire_shared(&mut self, key: String) {
-        debug!("Acquiring shared lock for key: {}", key);
+    pub(crate) async fn prepare_lock<'a>(&'a self, key: String) -> Box<dyn Lock + 'a + Send> {
         match self {
-            LocksStorage::Memory(lock) => {
-                lock.acquire_shared(key);
-            }
-        }
-    }
-
-    /**
-     * Acquire exclusive lock for key
-     */
-    pub fn acquire_exclusive(&mut self, key: String) {
-        debug!("Acquiring exclusive lock for key: {}", key);
-        match self {
-            LocksStorage::Memory(lock) => {
-                lock.acquire_exclusive(key);
-            }
-        }
-    }
-
-    /**
-     * Release lock for key
-     */
-    pub fn release(&mut self, key: impl AsRef<str> + Display) -> bool {
-        debug!("Releasing lock for key: {}", key);
-        match self {
-            LocksStorage::Memory(lock) => lock.release(key),
+            LocksStorage::Memory(memory_locks) => memory_locks.prepare_lock(key).await,
         }
     }
 }

--- a/src/locks/mod.rs
+++ b/src/locks/mod.rs
@@ -25,10 +25,13 @@ pub enum LocksType {
     Memory,
 }
 
+#[must_use = "droping temporary lock makes no sense"]
 pub(crate) trait SharedLockGuard<'a> {}
+#[must_use = "droping temporary lock makes no sense"]
 pub(crate) trait ExclusiveLockGuard<'a> {}
 
 #[async_trait]
+#[must_use = "preparing temporary lock makes no sense"]
 pub(crate) trait Lock {
     async fn acquire_shared<'a>(&'a self) -> Box<dyn SharedLockGuard<'a> + 'a + Send>;
     async fn acquire_exclusive<'a>(&'a self) -> Box<dyn ExclusiveLockGuard<'a> + 'a + Send>;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,4 +1,4 @@
-use tracing::dispatcher::SetGlobalDefaultError;
+use anyhow::Result;
 use tracing_subscriber::{EnvFilter, fmt};
 
 #[derive(Clone, Debug, serde::Deserialize)]
@@ -7,16 +7,16 @@ pub struct LoggingConfig {
     pub json: bool,
 }
 
-pub fn setup(logging_config: &LoggingConfig) -> Result<(), SetGlobalDefaultError> {
+pub fn setup(logging_config: &LoggingConfig) -> Result<()> {
     let filter = EnvFilter::new(&logging_config.level);
     if logging_config.json {
         let subscriber = fmt::Subscriber::builder()
             .with_env_filter(filter)
             .json()
             .finish();
-        tracing::subscriber::set_global_default(subscriber)
+        Ok(tracing::subscriber::set_global_default(subscriber)?)
     } else {
         let subscriber = fmt::Subscriber::builder().with_env_filter(filter).finish();
-        tracing::subscriber::set_global_default(subscriber)
+        Ok(tracing::subscriber::set_global_default(subscriber)?)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,7 +115,7 @@ async fn run_s3dedup_server(config_path: Option<&str>, use_env: bool) {
                     .make_span_with(DefaultMakeSpan::new().level(Level::INFO))
                     .on_response(DefaultOnResponse::new().level(Level::INFO)),
             )
-            .with_state(Arc::new(app_state));
+            .with_state(app_state);
         let address: SocketAddr = format!("{}:{}", bucket.address, bucket.port)
             .parse()
             .unwrap();
@@ -161,7 +161,7 @@ async fn run_migrate(
 
     // Initialize AppState
     let app_state = match AppState::new(bucket_config).await {
-        Ok(state) => Arc::new(state),
+        Ok(state) => state,
         Err(e) => {
             error!("Failed to initialize app state: {}", e);
             return;
@@ -267,7 +267,7 @@ async fn run_live_migrate(config_path: Option<&str>, use_env: bool, max_concurre
                             .make_span_with(DefaultMakeSpan::new().level(Level::INFO))
                             .on_response(DefaultOnResponse::new().level(Level::INFO)),
                     )
-                    .with_state(Arc::new(app_state));
+                    .with_state(app_state);
 
                 let address: SocketAddr = format!("{}:{}", bucket.address, bucket.port)
                     .parse()
@@ -303,7 +303,7 @@ async fn run_live_migrate(config_path: Option<&str>, use_env: bool, max_concurre
         tokio::spawn(async move {
             s3dedup::migration::live_migration_worker(
                 migration_client,
-                Arc::new(migration_app_state),
+                migration_app_state,
                 max_concurrency,
             )
             .await;
@@ -336,7 +336,7 @@ async fn run_live_migrate(config_path: Option<&str>, use_env: bool, max_concurre
                     .make_span_with(DefaultMakeSpan::new().level(Level::INFO))
                     .on_response(DefaultOnResponse::new().level(Level::INFO)),
             )
-            .with_state(Arc::new(app_state));
+            .with_state(app_state);
 
         let address: SocketAddr = format!("{}:{}", bucket.address, bucket.port)
             .parse()

--- a/src/migration/mod.rs
+++ b/src/migration/mod.rs
@@ -164,7 +164,7 @@ pub async fn migrate_single_file_from_metadata(
     let lock_key = crate::locks::file_lock(&app_state.bucket_name, path);
     let locks = &app_state.locks;
     let lock = locks.prepare_lock(lock_key).await;
-    let _guard = lock.acquire_exclusive();
+    let _guard = lock.acquire_exclusive().await;
 
     // Recheck if file was already migrated after acquiring lock (race condition protection)
     let current_modified_after_lock = app_state
@@ -307,7 +307,7 @@ async fn migrate_single_file(
     let lock_key = crate::locks::file_lock(&app_state.bucket_name, path);
     let locks_storage = &app_state.locks;
     let lock = locks_storage.prepare_lock(lock_key).await;
-    let _guard = lock.acquire_exclusive();
+    let _guard = lock.acquire_exclusive().await;
 
     // Recheck if file was already migrated after acquiring lock (race condition protection)
     let current_modified_after_lock = app_state

--- a/src/migration/mod.rs
+++ b/src/migration/mod.rs
@@ -1,6 +1,7 @@
 use crate::AppState;
 use crate::filetracker_client::{FileMetadata, FiletrackerClient};
 use crate::routes::ft::storage_helpers;
+use anyhow::Result;
 use std::sync::Arc;
 use tokio::sync::Semaphore;
 use tracing::{error, info, warn};
@@ -17,7 +18,7 @@ pub async fn migrate_all_files(
     filetracker_client: Arc<FiletrackerClient>,
     app_state: Arc<AppState>,
     max_concurrency: usize,
-) -> Result<MigrationStats, Box<dyn std::error::Error + Send + Sync>> {
+) -> Result<MigrationStats> {
     info!("Starting offline migration from filetracker to s3dedup");
     info!("Max concurrency: {}", max_concurrency);
 
@@ -132,7 +133,7 @@ pub async fn migrate_single_file_from_metadata(
     app_state: &AppState,
     path: &str,
     file_metadata: FileMetadata,
-) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+) -> Result<()> {
     // Check if file already exists in s3dedup with same or newer version
     let current_modified = app_state
         .kvstorage
@@ -272,7 +273,7 @@ async fn migrate_single_file(
     filetracker_client: &FiletrackerClient,
     app_state: Arc<AppState>,
     path: &str,
-) -> Result<bool, Box<dyn std::error::Error + Send + Sync>> {
+) -> Result<bool> {
     // Get file from filetracker
     let file_metadata = filetracker_client.get_file(path).await?;
 

--- a/src/migration/mod.rs
+++ b/src/migration/mod.rs
@@ -160,7 +160,11 @@ pub async fn migrate_single_file_from_metadata(
 
     // Acquire file lock
     let lock_key = crate::locks::file_lock(&app_state.bucket_name, path);
-    app_state.locks.lock().await.acquire_exclusive(&lock_key);
+    app_state
+        .locks
+        .lock()
+        .await
+        .acquire_exclusive(lock_key.clone());
 
     // Recheck if file was already migrated after acquiring lock (race condition protection)
     let current_modified_after_lock = app_state
@@ -263,7 +267,7 @@ pub async fn migrate_single_file_from_metadata(
         .await?;
 
     // Release lock
-    app_state.locks.lock().await.release(&lock_key);
+    app_state.locks.lock().await.release(lock_key);
 
     Ok(())
 }
@@ -306,7 +310,11 @@ async fn migrate_single_file(
 
     // Acquire file lock
     let lock_key = crate::locks::file_lock(&app_state.bucket_name, path);
-    app_state.locks.lock().await.acquire_exclusive(&lock_key);
+    app_state
+        .locks
+        .lock()
+        .await
+        .acquire_exclusive(lock_key.clone());
 
     // Recheck if file was already migrated after acquiring lock (race condition protection)
     let current_modified_after_lock = app_state
@@ -409,7 +417,7 @@ async fn migrate_single_file(
         .await?;
 
     // Release lock
-    app_state.locks.lock().await.release(&lock_key);
+    app_state.locks.lock().await.release(lock_key);
 
     Ok(true)
 }

--- a/src/migration/mod.rs
+++ b/src/migration/mod.rs
@@ -85,7 +85,7 @@ pub async fn migrate_all_files(
                 }
 
                 // Migrate the file
-                match migrate_single_file(&filetracker_client, &app_state, &path).await {
+                match migrate_single_file(&filetracker_client, app_state, &path).await {
                     Ok(true) => {
                         *migrated.lock().await += 1;
                     }
@@ -103,6 +103,7 @@ pub async fn migrate_all_files(
         }
 
         // Wait for this batch to complete before moving to next batch
+        // TODO: futures_util::join_all;
         for handle in handles {
             let _ = handle.await;
         }
@@ -160,11 +161,9 @@ pub async fn migrate_single_file_from_metadata(
 
     // Acquire file lock
     let lock_key = crate::locks::file_lock(&app_state.bucket_name, path);
-    app_state
-        .locks
-        .lock()
-        .await
-        .acquire_exclusive(lock_key.clone());
+    let locks = app_state.locks.lock().await;
+    let lock = locks.prepare_lock(lock_key).await;
+    let _guard = lock.acquire_exclusive();
 
     // Recheck if file was already migrated after acquiring lock (race condition protection)
     let current_modified_after_lock = app_state
@@ -176,7 +175,6 @@ pub async fn migrate_single_file_from_metadata(
 
     if current_modified_after_lock >= file_metadata.last_modified {
         // File was migrated by another concurrent task, skip
-        app_state.locks.lock().await.release(&lock_key);
         return Ok(());
     }
 
@@ -265,10 +263,6 @@ pub async fn migrate_single_file_from_metadata(
         .await
         .set_modified(&app_state.bucket_name, path, file_metadata.last_modified)
         .await?;
-
-    // Release lock
-    app_state.locks.lock().await.release(lock_key);
-
     Ok(())
 }
 
@@ -276,7 +270,7 @@ pub async fn migrate_single_file_from_metadata(
 /// Returns Ok(true) if migrated, Ok(false) if skipped, Err if failed
 async fn migrate_single_file(
     filetracker_client: &FiletrackerClient,
-    app_state: &AppState,
+    app_state: Arc<AppState>,
     path: &str,
 ) -> Result<bool, Box<dyn std::error::Error + Send + Sync>> {
     // Get file from filetracker
@@ -310,11 +304,9 @@ async fn migrate_single_file(
 
     // Acquire file lock
     let lock_key = crate::locks::file_lock(&app_state.bucket_name, path);
-    app_state
-        .locks
-        .lock()
-        .await
-        .acquire_exclusive(lock_key.clone());
+    let locks_storage = app_state.locks.lock().await;
+    let lock = locks_storage.prepare_lock(lock_key).await;
+    let _guard = lock.acquire_exclusive();
 
     // Recheck if file was already migrated after acquiring lock (race condition protection)
     let current_modified_after_lock = app_state
@@ -326,7 +318,6 @@ async fn migrate_single_file(
 
     if current_modified_after_lock >= file_metadata.last_modified {
         // File was migrated by another concurrent task, skip
-        app_state.locks.lock().await.release(&lock_key);
         return Ok(false);
     }
 
@@ -415,9 +406,6 @@ async fn migrate_single_file(
         .await
         .set_modified(&app_state.bucket_name, path, file_metadata.last_modified)
         .await?;
-
-    // Release lock
-    app_state.locks.lock().await.release(lock_key);
 
     Ok(true)
 }

--- a/src/migration/mod.rs
+++ b/src/migration/mod.rs
@@ -162,7 +162,7 @@ pub async fn migrate_single_file_from_metadata(
 
     // Acquire file lock
     let lock_key = crate::locks::file_lock(&app_state.bucket_name, path);
-    let locks = app_state.locks.lock().await;
+    let locks = &app_state.locks;
     let lock = locks.prepare_lock(lock_key).await;
     let _guard = lock.acquire_exclusive();
 
@@ -305,7 +305,7 @@ async fn migrate_single_file(
 
     // Acquire file lock
     let lock_key = crate::locks::file_lock(&app_state.bucket_name, path);
-    let locks_storage = app_state.locks.lock().await;
+    let locks_storage = &app_state.locks;
     let lock = locks_storage.prepare_lock(lock_key).await;
     let _guard = lock.acquire_exclusive();
 

--- a/src/migration/mod.rs
+++ b/src/migration/mod.rs
@@ -163,7 +163,7 @@ pub async fn migrate_single_file_from_metadata(
     // Acquire file lock
     let lock_key = crate::locks::file_lock(&app_state.bucket_name, path);
     let locks = &app_state.locks;
-    let lock = locks.prepare_lock(lock_key).await;
+    let lock = locks.prepare_lock(lock_key);
     let _guard = lock.acquire_exclusive().await;
 
     // Recheck if file was already migrated after acquiring lock (race condition protection)
@@ -306,7 +306,7 @@ async fn migrate_single_file(
     // Acquire file lock
     let lock_key = crate::locks::file_lock(&app_state.bucket_name, path);
     let locks_storage = &app_state.locks;
-    let lock = locks_storage.prepare_lock(lock_key).await;
+    let lock = locks_storage.prepare_lock(lock_key);
     let _guard = lock.acquire_exclusive().await;
 
     // Recheck if file was already migrated after acquiring lock (race condition protection)

--- a/src/routes/ft/delete_file.rs
+++ b/src/routes/ft/delete_file.rs
@@ -29,7 +29,7 @@ pub async fn ft_delete_file(
 
     // 2. Acquire file lock (exclusive for write operation)
     let lock_key = locks::file_lock(&state.bucket_name, path);
-    state.locks.lock().await.acquire_exclusive(&lock_key);
+    state.locks.lock().await.acquire_exclusive(lock_key.clone());
 
     // 3. Check if file exists
     let current_modified = state
@@ -106,7 +106,7 @@ pub async fn ft_delete_file(
         .await
     {
         error!("Failed to decrement ref count: {}", e);
-        state.locks.lock().await.release(&lock_key);
+        state.locks.lock().await.release(lock_key);
         return Response::builder()
             .status(StatusCode::INTERNAL_SERVER_ERROR)
             .body("Failed to decrement ref count".to_string())
@@ -188,7 +188,7 @@ pub async fn ft_delete_file(
     }
 
     // 10. Release lock and return
-    state.locks.lock().await.release(&lock_key);
+    state.locks.lock().await.release(lock_key);
 
     Response::builder()
         .status(StatusCode::OK)

--- a/src/routes/ft/delete_file.rs
+++ b/src/routes/ft/delete_file.rs
@@ -30,7 +30,7 @@ pub async fn ft_delete_file(
     // 2. Acquire file lock (exclusive for write operation)
     let lock_key = locks::file_lock(&state.bucket_name, path);
     let locks_storage = &state.locks;
-    let lock = locks_storage.prepare_lock(lock_key).await;
+    let lock = locks_storage.prepare_lock(lock_key);
     let _guard = lock.acquire_exclusive().await;
 
     // 3. Check if file exists

--- a/src/routes/ft/delete_file.rs
+++ b/src/routes/ft/delete_file.rs
@@ -29,7 +29,7 @@ pub async fn ft_delete_file(
 
     // 2. Acquire file lock (exclusive for write operation)
     let lock_key = locks::file_lock(&state.bucket_name, path);
-    let locks_storage = state.locks.lock().await;
+    let locks_storage = &state.locks;
     let lock = locks_storage.prepare_lock(lock_key).await;
     let _guard = lock.acquire_exclusive().await;
 

--- a/src/routes/ft/delete_file.rs
+++ b/src/routes/ft/delete_file.rs
@@ -29,7 +29,9 @@ pub async fn ft_delete_file(
 
     // 2. Acquire file lock (exclusive for write operation)
     let lock_key = locks::file_lock(&state.bucket_name, path);
-    state.locks.lock().await.acquire_exclusive(lock_key.clone());
+    let locks_storage = state.locks.lock().await;
+    let lock = locks_storage.prepare_lock(lock_key).await;
+    let _guard = lock.acquire_exclusive().await;
 
     // 3. Check if file exists
     let current_modified = state
@@ -40,7 +42,6 @@ pub async fn ft_delete_file(
         .await;
     if current_modified.is_err() {
         error!("Failed to get current modified");
-        state.locks.lock().await.release(&lock_key);
         return Response::builder()
             .status(StatusCode::INTERNAL_SERVER_ERROR)
             .body("Failed to get current modified".to_string())
@@ -51,7 +52,6 @@ pub async fn ft_delete_file(
     // If file doesn't exist, return 404
     if current_modified == 0 {
         debug!("File {} not found", path);
-        state.locks.lock().await.release(&lock_key);
         return Response::builder()
             .status(StatusCode::NOT_FOUND)
             .body("File not found".to_string())
@@ -64,7 +64,6 @@ pub async fn ft_delete_file(
             "Tried to delete newer version of {} ({} < {}), ignoring.",
             path, timestamp, current_modified
         );
-        state.locks.lock().await.release(&lock_key);
         return Response::builder()
             .status(StatusCode::OK)
             .body("".to_string())
@@ -80,7 +79,6 @@ pub async fn ft_delete_file(
         .await;
     if hash.is_err() {
         error!("Failed to get ref file");
-        state.locks.lock().await.release(&lock_key);
         return Response::builder()
             .status(StatusCode::INTERNAL_SERVER_ERROR)
             .body("Failed to get ref file".to_string())
@@ -90,7 +88,6 @@ pub async fn ft_delete_file(
 
     if hash.is_empty() {
         error!("File {} has no hash reference", path);
-        state.locks.lock().await.release(&lock_key);
         return Response::builder()
             .status(StatusCode::NOT_FOUND)
             .body("File has no hash reference".to_string())
@@ -106,7 +103,6 @@ pub async fn ft_delete_file(
         .await
     {
         error!("Failed to decrement ref count: {}", e);
-        state.locks.lock().await.release(lock_key);
         return Response::builder()
             .status(StatusCode::INTERNAL_SERVER_ERROR)
             .body("Failed to decrement ref count".to_string())
@@ -146,7 +142,6 @@ pub async fn ft_delete_file(
         .await
     {
         error!("Failed to delete ref file: {}", e);
-        state.locks.lock().await.release(&lock_key);
         return Response::builder()
             .status(StatusCode::INTERNAL_SERVER_ERROR)
             .body("Failed to delete ref file".to_string())
@@ -161,7 +156,6 @@ pub async fn ft_delete_file(
         .await
     {
         error!("Failed to delete modified time: {}", e);
-        state.locks.lock().await.release(&lock_key);
         return Response::builder()
             .status(StatusCode::INTERNAL_SERVER_ERROR)
             .body("Failed to delete modified time".to_string())
@@ -186,9 +180,6 @@ pub async fn ft_delete_file(
             debug!("Successfully deleted from filetracker");
         }
     }
-
-    // 10. Release lock and return
-    state.locks.lock().await.release(lock_key);
 
     Response::builder()
         .status(StatusCode::OK)

--- a/src/routes/ft/get_file.rs
+++ b/src/routes/ft/get_file.rs
@@ -19,7 +19,7 @@ pub async fn ft_get_file(
 
     // 1. Acquire file lock (shared lock for read operation)
     let lock_key = locks::file_lock(&state.bucket_name, path);
-    let locks_storage = state.locks.lock().await;
+    let locks_storage = &state.locks;
     let lock = locks_storage.prepare_lock(lock_key).await;
     let _guard = lock.acquire_shared().await;
 

--- a/src/routes/ft/get_file.rs
+++ b/src/routes/ft/get_file.rs
@@ -19,7 +19,9 @@ pub async fn ft_get_file(
 
     // 1. Acquire file lock (shared lock for read operation)
     let lock_key = locks::file_lock(&state.bucket_name, path);
-    state.locks.lock().await.acquire_shared(lock_key.clone());
+    let locks_storage = state.locks.lock().await;
+    let lock = locks_storage.prepare_lock(lock_key).await;
+    let _guard = lock.acquire_shared().await;
 
     // 2. Check if file exists and get metadata
     let modified_time = state
@@ -30,8 +32,6 @@ pub async fn ft_get_file(
         .await;
     if modified_time.is_err() {
         error!("Failed to get modified time");
-        state.locks.lock().await.release(lock_key);
-
         metrics::HTTP_REQUESTS_TOTAL
             .with_label_values(&["GET", "/ft/files", "500"])
             .inc();
@@ -71,8 +71,6 @@ pub async fn ft_get_file(
 
                     if let Err(e) = result {
                         error!("Failed to migrate file on-the-fly: {}", e);
-                        state.locks.lock().await.release(&lock_key);
-
                         metrics::HTTP_REQUESTS_TOTAL
                             .with_label_values(&["GET", "/ft/files", "500"])
                             .inc();
@@ -85,9 +83,6 @@ pub async fn ft_get_file(
                             .body(Body::empty())
                             .unwrap();
                     }
-
-                    // Release lock
-                    state.locks.lock().await.release(&lock_key);
 
                     metrics::HTTP_REQUESTS_TOTAL
                         .with_label_values(&["GET", "/ft/files", "200"])
@@ -124,8 +119,6 @@ pub async fn ft_get_file(
         }
 
         debug!("File {} not found", path);
-        state.locks.lock().await.release(&lock_key);
-
         metrics::HTTP_REQUESTS_TOTAL
             .with_label_values(&["GET", "/ft/files", "404"])
             .inc();
@@ -148,7 +141,6 @@ pub async fn ft_get_file(
         .await;
     if hash.is_err() {
         error!("Failed to get ref file");
-        state.locks.lock().await.release(&lock_key);
         return Response::builder()
             .status(StatusCode::INTERNAL_SERVER_ERROR)
             .body(Body::empty())
@@ -158,7 +150,6 @@ pub async fn ft_get_file(
 
     if hash.is_empty() {
         error!("File {} has no hash reference", path);
-        state.locks.lock().await.release(&lock_key);
         return Response::builder()
             .status(StatusCode::NOT_FOUND)
             .body(Body::empty())
@@ -174,7 +165,6 @@ pub async fn ft_get_file(
         .await;
     if logical_size.is_err() {
         error!("Failed to get logical size");
-        state.locks.lock().await.release(&lock_key);
         return Response::builder()
             .status(StatusCode::INTERNAL_SERVER_ERROR)
             .body(Body::empty())
@@ -186,7 +176,6 @@ pub async fn ft_get_file(
     let blob_data = state.s3storage.lock().await.get_object(&hash).await;
     if blob_data.is_err() {
         error!("Failed to get object from S3: {}", blob_data.err().unwrap());
-        state.locks.lock().await.release(&lock_key);
         return Response::builder()
             .status(StatusCode::INTERNAL_SERVER_ERROR)
             .body(Body::empty())
@@ -194,10 +183,7 @@ pub async fn ft_get_file(
     }
     let blob_data = blob_data.unwrap();
 
-    // 6. Release lock
-    state.locks.lock().await.release(lock_key);
-
-    // 7. Record metrics
+    // 6. Record metrics
     metrics::HTTP_REQUESTS_TOTAL
         .with_label_values(&["GET", "/ft/files", "200"])
         .inc();
@@ -205,7 +191,7 @@ pub async fn ft_get_file(
         .with_label_values(&["GET", "/ft/files"])
         .observe(start.elapsed().as_secs_f64());
 
-    // 8. Return file with appropriate headers (matching original filetracker)
+    // 7. Return file with appropriate headers (matching original filetracker)
     Response::builder()
         .status(StatusCode::OK)
         .header("Content-Type", "application/octet-stream")

--- a/src/routes/ft/get_file.rs
+++ b/src/routes/ft/get_file.rs
@@ -19,7 +19,7 @@ pub async fn ft_get_file(
 
     // 1. Acquire file lock (shared lock for read operation)
     let lock_key = locks::file_lock(&state.bucket_name, path);
-    state.locks.lock().await.acquire_shared(&lock_key);
+    state.locks.lock().await.acquire_shared(lock_key.clone());
 
     // 2. Check if file exists and get metadata
     let modified_time = state
@@ -30,7 +30,7 @@ pub async fn ft_get_file(
         .await;
     if modified_time.is_err() {
         error!("Failed to get modified time");
-        state.locks.lock().await.release(&lock_key);
+        state.locks.lock().await.release(lock_key);
 
         metrics::HTTP_REQUESTS_TOTAL
             .with_label_values(&["GET", "/ft/files", "500"])
@@ -195,7 +195,7 @@ pub async fn ft_get_file(
     let blob_data = blob_data.unwrap();
 
     // 6. Release lock
-    state.locks.lock().await.release(&lock_key);
+    state.locks.lock().await.release(lock_key);
 
     // 7. Record metrics
     metrics::HTTP_REQUESTS_TOTAL

--- a/src/routes/ft/get_file.rs
+++ b/src/routes/ft/get_file.rs
@@ -20,7 +20,7 @@ pub async fn ft_get_file(
     // 1. Acquire file lock (shared lock for read operation)
     let lock_key = locks::file_lock(&state.bucket_name, path);
     let locks_storage = &state.locks;
-    let lock = locks_storage.prepare_lock(lock_key).await;
+    let lock = locks_storage.prepare_lock(lock_key);
     let guard = lock.acquire_shared().await;
 
     // 2. Check if file exists and get metadata

--- a/src/routes/ft/get_file.rs
+++ b/src/routes/ft/get_file.rs
@@ -21,7 +21,7 @@ pub async fn ft_get_file(
     let lock_key = locks::file_lock(&state.bucket_name, path);
     let locks_storage = &state.locks;
     let lock = locks_storage.prepare_lock(lock_key).await;
-    let _guard = lock.acquire_shared().await;
+    let guard = lock.acquire_shared().await;
 
     // 2. Check if file exists and get metadata
     let modified_time = state
@@ -63,7 +63,7 @@ pub async fn ft_get_file(
 
                     // Drop the shared lock before migration to avoid deadlock
                     // (migration needs exclusive lock on the same key)
-                    drop(_guard);
+                    drop(guard);
 
                     // Migrate the file on-the-fly using migration logic
                     let result = crate::migration::migrate_single_file_from_metadata(
@@ -187,7 +187,7 @@ pub async fn ft_get_file(
     }
     let blob_data = blob_data.unwrap();
 
-    drop(_guard);
+    drop(guard);
 
     // 6. Record metrics
     metrics::HTTP_REQUESTS_TOTAL

--- a/src/routes/ft/get_file.rs
+++ b/src/routes/ft/get_file.rs
@@ -61,6 +61,10 @@ pub async fn ft_get_file(
                         .with_label_values(&[&state.bucket_name])
                         .inc();
 
+                    // Drop the shared lock before migration to avoid deadlock
+                    // (migration needs exclusive lock on the same key)
+                    drop(_guard);
+
                     // Migrate the file on-the-fly using migration logic
                     let result = crate::migration::migrate_single_file_from_metadata(
                         &state,
@@ -182,6 +186,8 @@ pub async fn ft_get_file(
             .unwrap();
     }
     let blob_data = blob_data.unwrap();
+
+    drop(_guard);
 
     // 6. Record metrics
     metrics::HTTP_REQUESTS_TOTAL

--- a/src/routes/ft/put_file.rs
+++ b/src/routes/ft/put_file.rs
@@ -68,7 +68,7 @@ pub async fn ft_put_file(
 
     // 4. Acquire file lock
     let lock_key = locks::file_lock(&state.bucket_name, path);
-    let locks_storage = state.locks.lock().await;
+    let locks_storage = &state.locks;
     let lock = locks_storage.prepare_lock(lock_key).await;
     let _guard = lock.acquire_exclusive();
 

--- a/src/routes/ft/put_file.rs
+++ b/src/routes/ft/put_file.rs
@@ -68,7 +68,7 @@ pub async fn ft_put_file(
 
     // 4. Acquire file lock
     let lock_key = locks::file_lock(&state.bucket_name, path);
-    state.locks.lock().await.acquire_exclusive(&lock_key);
+    state.locks.lock().await.acquire_exclusive(lock_key.clone());
 
     // 5. Check existing version (matching original logic)
     let current_modified = state

--- a/src/routes/ft/put_file.rs
+++ b/src/routes/ft/put_file.rs
@@ -68,7 +68,9 @@ pub async fn ft_put_file(
 
     // 4. Acquire file lock
     let lock_key = locks::file_lock(&state.bucket_name, path);
-    state.locks.lock().await.acquire_exclusive(lock_key.clone());
+    let locks_storage = state.locks.lock().await;
+    let lock = locks_storage.prepare_lock(lock_key).await;
+    let _guard = lock.acquire_exclusive();
 
     // 5. Check existing version (matching original logic)
     let current_modified = state
@@ -79,7 +81,6 @@ pub async fn ft_put_file(
         .await;
     if current_modified.is_err() {
         error!("Failed to get current modified");
-        state.locks.lock().await.release(&lock_key);
         return Response::builder()
             .status(StatusCode::INTERNAL_SERVER_ERROR)
             .body("Failed to get current modified".to_string())
@@ -93,7 +94,6 @@ pub async fn ft_put_file(
             "Tried to store older version of {} ({} < {}), ignoring.",
             path, timestamp, current_modified
         );
-        state.locks.lock().await.release(&lock_key);
         return Response::builder()
             .status(StatusCode::OK)
             .header("Content-Type", "text/plain")
@@ -118,7 +118,6 @@ pub async fn ft_put_file(
                 Ok(data) => data,
                 Err(e) => {
                     error!("Failed to decompress gzip data: {}", e);
-                    state.locks.lock().await.release(&lock_key);
                     return Response::builder()
                         .status(StatusCode::BAD_REQUEST)
                         .body("Failed to decompress gzip data".to_string())
@@ -140,7 +139,6 @@ pub async fn ft_put_file(
                 Ok(data) => data,
                 Err(e) => {
                     error!("Failed to compress data: {}", e);
-                    state.locks.lock().await.release(&lock_key);
                     return Response::builder()
                         .status(StatusCode::INTERNAL_SERVER_ERROR)
                         .body("Failed to compress data".to_string())
@@ -161,7 +159,6 @@ pub async fn ft_put_file(
         Ok(exists) => exists,
         Err(e) => {
             error!("Failed to check object existence: {}", e);
-            state.locks.lock().await.release(&lock_key);
             return Response::builder()
                 .status(StatusCode::INTERNAL_SERVER_ERROR)
                 .body("Failed to check object existence".to_string())
@@ -181,7 +178,6 @@ pub async fn ft_put_file(
             .await
         {
             error!("Failed to store object in S3: {}", e);
-            state.locks.lock().await.release(&lock_key);
             return Response::builder()
                 .status(StatusCode::INTERNAL_SERVER_ERROR)
                 .body("Failed to store object".to_string())
@@ -198,7 +194,6 @@ pub async fn ft_put_file(
         .await
     {
         error!("Failed to store logical size: {}", e);
-        state.locks.lock().await.release(&lock_key);
         return Response::builder()
             .status(StatusCode::INTERNAL_SERVER_ERROR)
             .body("Failed to store logical size".to_string())
@@ -214,7 +209,6 @@ pub async fn ft_put_file(
         .await
     {
         error!("Failed to increment ref count: {}", e);
-        state.locks.lock().await.release(&lock_key);
         return Response::builder()
             .status(StatusCode::INTERNAL_SERVER_ERROR)
             .body("Failed to increment ref count".to_string())
@@ -273,7 +267,6 @@ pub async fn ft_put_file(
         .await
     {
         error!("Failed to set ref file: {}", e);
-        state.locks.lock().await.release(&lock_key);
         return Response::builder()
             .status(StatusCode::INTERNAL_SERVER_ERROR)
             .body("Failed to set ref file".to_string())
@@ -288,7 +281,6 @@ pub async fn ft_put_file(
         .await
     {
         error!("Failed to set modified time: {}", e);
-        state.locks.lock().await.release(&lock_key);
         return Response::builder()
             .status(StatusCode::INTERNAL_SERVER_ERROR)
             .body("Failed to set modified time".to_string())
@@ -324,9 +316,6 @@ pub async fn ft_put_file(
             debug!("Successfully wrote to filetracker");
         }
     }
-
-    // 10. Release lock and return (matching original response format)
-    state.locks.lock().await.release(&lock_key);
 
     Response::builder()
         .status(StatusCode::OK)

--- a/src/routes/ft/put_file.rs
+++ b/src/routes/ft/put_file.rs
@@ -69,7 +69,7 @@ pub async fn ft_put_file(
     // 4. Acquire file lock
     let lock_key = locks::file_lock(&state.bucket_name, path);
     let locks_storage = &state.locks;
-    let lock = locks_storage.prepare_lock(lock_key).await;
+    let lock = locks_storage.prepare_lock(lock_key);
     let _guard = lock.acquire_exclusive().await;
 
     // 5. Check existing version (matching original logic)

--- a/src/routes/ft/put_file.rs
+++ b/src/routes/ft/put_file.rs
@@ -70,7 +70,7 @@ pub async fn ft_put_file(
     let lock_key = locks::file_lock(&state.bucket_name, path);
     let locks_storage = &state.locks;
     let lock = locks_storage.prepare_lock(lock_key).await;
-    let _guard = lock.acquire_exclusive();
+    let _guard = lock.acquire_exclusive().await;
 
     // 5. Check existing version (matching original logic)
     let current_modified = state

--- a/src/routes/ft/storage_helpers.rs
+++ b/src/routes/ft/storage_helpers.rs
@@ -1,6 +1,6 @@
+use anyhow::Result;
 use bytes::Bytes;
 use sha2::{Digest, Sha256};
-use std::error::Error;
 use std::io::Read;
 
 pub fn compute_sha256(data: &[u8]) -> String {
@@ -9,7 +9,7 @@ pub fn compute_sha256(data: &[u8]) -> String {
     format!("{:x}", hasher.finalize())
 }
 
-pub fn compress_gzip(data: &[u8]) -> Result<Vec<u8>, Box<dyn Error + Send + Sync>> {
+pub fn compress_gzip(data: &[u8]) -> Result<Vec<u8>> {
     use flate2::Compression;
     use flate2::write::GzEncoder;
     use std::io::Write;
@@ -20,7 +20,7 @@ pub fn compress_gzip(data: &[u8]) -> Result<Vec<u8>, Box<dyn Error + Send + Sync
     Ok(compressed)
 }
 
-pub fn decompress_gzip(data: &[u8]) -> Result<Vec<u8>, Box<dyn Error + Send + Sync>> {
+pub fn decompress_gzip(data: &[u8]) -> Result<Vec<u8>> {
     use flate2::read::GzDecoder;
 
     let mut decoder = GzDecoder::new(data);
@@ -29,9 +29,7 @@ pub fn decompress_gzip(data: &[u8]) -> Result<Vec<u8>, Box<dyn Error + Send + Sy
     Ok(decompressed)
 }
 
-pub async fn read_body_bytes(
-    body: axum::body::Body,
-) -> Result<Bytes, Box<dyn Error + Send + Sync>> {
+pub async fn read_body_bytes(body: axum::body::Body) -> Result<Bytes> {
     use axum::body::to_bytes;
 
     let bytes = to_bytes(body, usize::MAX).await?;

--- a/src/routes/ft/utils.rs
+++ b/src/routes/ft/utils.rs
@@ -1,7 +1,7 @@
+use anyhow::Result;
 use chrono::{DateTime, TimeZone, Utc};
-use std::error::Error;
 
-pub fn conv_rfc2822_to_unix_timestamp(rfc2822: &str) -> Result<i64, Box<dyn Error + Send + Sync>> {
+pub fn conv_rfc2822_to_unix_timestamp(rfc2822: &str) -> Result<i64> {
     let dt = DateTime::parse_from_rfc2822(rfc2822)?;
     Ok(dt.timestamp())
 }

--- a/src/s3storage/minio.rs
+++ b/src/s3storage/minio.rs
@@ -1,12 +1,14 @@
 use crate::config::BucketConfig;
 use crate::s3storage::S3StorageTrait;
+use anyhow::Result;
+use anyhow::anyhow;
+use anyhow::bail;
 use async_trait::async_trait;
 use aws_config::BehaviorVersion;
 use aws_sdk_s3::config::{Credentials, Region};
 use aws_sdk_s3::primitives::ByteStream;
 use aws_sdk_s3::{Client, Config};
 use serde::Deserialize;
-use std::error::Error;
 use tracing::{debug, error};
 
 #[derive(Debug, Clone, Deserialize)]
@@ -30,8 +32,11 @@ pub struct MinIOClient {
 
 #[async_trait]
 impl S3StorageTrait for MinIOClient {
-    async fn new(config: &BucketConfig) -> Result<Box<Self>, Box<dyn Error + Send + Sync>> {
-        let minio_config = config.minio.as_ref().ok_or("MinIO config not found")?;
+    async fn new(config: &BucketConfig) -> Result<Box<Self>> {
+        let minio_config = config
+            .minio
+            .as_ref()
+            .ok_or_else(|| anyhow!("MinIO config not found"))?;
 
         debug!("Connecting to MinIO at: {}", minio_config.endpoint);
 
@@ -70,11 +75,7 @@ impl S3StorageTrait for MinIOClient {
         Ok(Box::new(minio_client))
     }
 
-    async fn put_object(
-        &self,
-        key: &str,
-        data: Vec<u8>,
-    ) -> Result<(), Box<dyn Error + Send + Sync>> {
+    async fn put_object(&self, key: &str, data: Vec<u8>) -> Result<()> {
         debug!("Putting object: {} (size: {} bytes)", key, data.len());
 
         self.client
@@ -90,7 +91,7 @@ impl S3StorageTrait for MinIOClient {
         Ok(())
     }
 
-    async fn get_object(&self, key: &str) -> Result<Vec<u8>, Box<dyn Error + Send + Sync>> {
+    async fn get_object(&self, key: &str) -> Result<Vec<u8>> {
         debug!("Getting object: {}", key);
 
         let resp = self
@@ -110,7 +111,7 @@ impl S3StorageTrait for MinIOClient {
         Ok(data)
     }
 
-    async fn delete_object(&self, key: &str) -> Result<(), Box<dyn Error + Send + Sync>> {
+    async fn delete_object(&self, key: &str) -> Result<()> {
         debug!("Deleting object: {}", key);
 
         let delete_future = self
@@ -128,16 +129,16 @@ impl S3StorageTrait for MinIOClient {
             }
             Ok(Err(e)) => {
                 tracing::error!("Failed to delete object {}: {}", key, e);
-                Err(Box::new(e))
+                bail!(e)
             }
             Err(_) => {
                 tracing::error!("Timeout deleting object {}", key);
-                Err("Timeout deleting object".into())
+                bail!("Timeout deleting object")
             }
         }
     }
 
-    async fn object_exists(&self, key: &str) -> Result<bool, Box<dyn Error + Send + Sync>> {
+    async fn object_exists(&self, key: &str) -> Result<bool> {
         debug!("Checking if object exists: {}", key);
 
         match self
@@ -166,7 +167,7 @@ impl S3StorageTrait for MinIOClient {
                     Ok(false)
                 } else {
                     debug!("Error checking object existence: {}", err);
-                    Err(Box::new(err))
+                    bail!(err)
                 }
             }
         }
@@ -175,7 +176,7 @@ impl S3StorageTrait for MinIOClient {
     async fn list_objects(
         &self,
         continuation_token: Option<String>,
-    ) -> Result<(Vec<String>, Option<String>), Box<dyn Error + Send + Sync>> {
+    ) -> Result<(Vec<String>, Option<String>)> {
         debug!(
             "Listing objects with continuation_token: {:?}",
             continuation_token
@@ -209,7 +210,7 @@ impl S3StorageTrait for MinIOClient {
 
 impl MinIOClient {
     /// Ensures the bucket exists, creating it if necessary
-    async fn ensure_bucket_exists(&self) -> Result<(), Box<dyn Error + Send + Sync>> {
+    async fn ensure_bucket_exists(&self) -> Result<()> {
         debug!("Checking if bucket exists: {}", self.bucket);
 
         // Try to check if bucket exists using head_bucket
@@ -255,13 +256,13 @@ impl MinIOClient {
                                 Ok(())
                             } else {
                                 error!("Failed to create bucket {}: {}", self.bucket, create_err);
-                                Err(Box::new(create_err))
+                                bail!(create_err)
                             }
                         }
                     }
                 } else {
                     error!("Error checking bucket existence: {}", err);
-                    Err(Box::new(err))
+                    bail!(err)
                 }
             }
         }

--- a/src/s3storage/mod.rs
+++ b/src/s3storage/mod.rs
@@ -1,7 +1,7 @@
 use crate::config::BucketConfig;
+use anyhow::Result;
 use async_trait::async_trait;
 use serde::Deserialize;
-use std::error::Error;
 use tracing::{debug, info};
 
 pub mod minio;
@@ -16,25 +16,21 @@ pub enum S3StorageType {
 
 #[async_trait]
 pub(crate) trait S3StorageTrait {
-    async fn new(config: &BucketConfig) -> Result<Box<Self>, Box<dyn Error + Send + Sync>>
+    async fn new(config: &BucketConfig) -> Result<Box<Self>>
     where
         Self: Sized;
 
-    async fn put_object(
-        &self,
-        key: &str,
-        data: Vec<u8>,
-    ) -> Result<(), Box<dyn Error + Send + Sync>>;
-    async fn get_object(&self, key: &str) -> Result<Vec<u8>, Box<dyn Error + Send + Sync>>;
-    async fn delete_object(&self, key: &str) -> Result<(), Box<dyn Error + Send + Sync>>;
-    async fn object_exists(&self, key: &str) -> Result<bool, Box<dyn Error + Send + Sync>>;
+    async fn put_object(&self, key: &str, data: Vec<u8>) -> Result<()>;
+    async fn get_object(&self, key: &str) -> Result<Vec<u8>>;
+    async fn delete_object(&self, key: &str) -> Result<()>;
+    async fn object_exists(&self, key: &str) -> Result<bool>;
 
     /// List objects in batches with continuation support
     /// Returns (keys, continuation_token)
     async fn list_objects(
         &self,
         continuation_token: Option<String>,
-    ) -> Result<(Vec<String>, Option<String>), Box<dyn Error + Send + Sync>>;
+    ) -> Result<(Vec<String>, Option<String>)>;
 }
 
 #[derive(Clone)]
@@ -43,7 +39,7 @@ pub enum S3Storage {
 }
 
 impl S3Storage {
-    pub async fn new(config: &BucketConfig) -> Result<Box<Self>, Box<dyn Error + Send + Sync>> {
+    pub async fn new(config: &BucketConfig) -> Result<Box<Self>> {
         match config.s3storage_type {
             S3StorageType::MinIO => {
                 info!("Using MinIO as S3 storage");
@@ -57,32 +53,28 @@ impl S3Storage {
         }
     }
 
-    pub async fn put_object(
-        &self,
-        key: &str,
-        data: Vec<u8>,
-    ) -> Result<(), Box<dyn Error + Send + Sync>> {
+    pub async fn put_object(&self, key: &str, data: Vec<u8>) -> Result<()> {
         debug!("Putting object with key: {}", key);
         match self {
             S3Storage::MinIO(client) => client.put_object(key, data).await,
         }
     }
 
-    pub async fn get_object(&self, key: &str) -> Result<Vec<u8>, Box<dyn Error + Send + Sync>> {
+    pub async fn get_object(&self, key: &str) -> Result<Vec<u8>> {
         debug!("Getting object with key: {}", key);
         match self {
             S3Storage::MinIO(client) => client.get_object(key).await,
         }
     }
 
-    pub async fn delete_object(&self, key: &str) -> Result<(), Box<dyn Error + Send + Sync>> {
+    pub async fn delete_object(&self, key: &str) -> Result<()> {
         debug!("Deleting object with key: {}", key);
         match self {
             S3Storage::MinIO(client) => client.delete_object(key).await,
         }
     }
 
-    pub async fn object_exists(&self, key: &str) -> Result<bool, Box<dyn Error + Send + Sync>> {
+    pub async fn object_exists(&self, key: &str) -> Result<bool> {
         debug!("Checking if object exists with key: {}", key);
         match self {
             S3Storage::MinIO(client) => client.object_exists(key).await,
@@ -92,7 +84,7 @@ impl S3Storage {
     pub async fn list_objects(
         &self,
         continuation_token: Option<String>,
-    ) -> Result<(Vec<String>, Option<String>), Box<dyn Error + Send + Sync>> {
+    ) -> Result<(Vec<String>, Option<String>)> {
         debug!(
             "Listing objects with continuation_token: {:?}",
             continuation_token

--- a/tests/cleaner_test.rs
+++ b/tests/cleaner_test.rs
@@ -60,7 +60,7 @@ async fn setup_test_env(
     (kvstorage, s3storage, bucket_name.to_string())
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_cleaner_config_defaults() {
     let config = CleanerConfig::default();
     assert!(!config.enabled);
@@ -69,7 +69,7 @@ async fn test_cleaner_config_defaults() {
     assert_eq!(config.max_deletes_per_run, 10000);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_cleaner_config_deserialization() {
     let json = r#"{
         "enabled": true,
@@ -85,7 +85,7 @@ async fn test_cleaner_config_deserialization() {
     assert_eq!(config.max_deletes_per_run, 5000);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_cleaner_config_partial_deserialization() {
     // Test that defaults work when fields are missing
     let json = r#"{"enabled": true}"#;
@@ -95,7 +95,7 @@ async fn test_cleaner_config_partial_deserialization() {
     assert_eq!(config.batch_size, 1000); // default
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_clean_orphaned_ref_files() {
     if !is_minio_available().await {
         eprintln!("Skipping test: MinIO not available");
@@ -170,7 +170,7 @@ async fn test_clean_orphaned_ref_files() {
     assert_eq!(modified1, 0); // Should be deleted
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_clean_unreferenced_refcounts() {
     if !is_minio_available().await {
         eprintln!("Skipping test: MinIO not available");
@@ -256,7 +256,7 @@ async fn test_clean_unreferenced_refcounts() {
     assert_eq!(count3, 1); // Should still exist
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_clean_unused_s3_objects() {
     if !is_minio_available().await {
         eprintln!("Skipping test: MinIO not available");
@@ -326,7 +326,7 @@ async fn test_clean_unused_s3_objects() {
     assert!(exists3); // Should still exist
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_clean_orphaned_logical_sizes() {
     if !is_minio_available().await {
         eprintln!("Skipping test: MinIO not available");
@@ -412,7 +412,7 @@ async fn test_clean_orphaned_logical_sizes() {
     assert_eq!(size3, 300); // Should still exist
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_max_deletes_per_run_limit() {
     if !is_minio_available().await {
         eprintln!("Skipping test: MinIO not available");
@@ -472,7 +472,7 @@ async fn test_max_deletes_per_run_limit() {
     assert_eq!(remaining, 15);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_batched_processing() {
     if !is_minio_available().await {
         eprintln!("Skipping test: MinIO not available");
@@ -525,7 +525,7 @@ async fn test_batched_processing() {
     }
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_full_cleanup_cycle() {
     if !is_minio_available().await {
         eprintln!("Skipping test: MinIO not available");

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -122,7 +122,7 @@ async fn create_test_app_with_state() -> (Router, Arc<s3dedup::AppState>) {
     (router, app_state)
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_get_nonexistent_file() {
     let app = create_test_app().await;
 
@@ -140,7 +140,7 @@ async fn test_get_nonexistent_file() {
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_put_and_get_file() {
     let app = create_test_app().await;
 
@@ -219,7 +219,7 @@ async fn test_put_and_get_file() {
     assert_eq!(decompressed, test_content);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_put_twice_same_content() {
     let app = create_test_app().await;
 
@@ -320,7 +320,7 @@ async fn test_put_twice_same_content() {
     assert_eq!(decompressed2, test_content);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_get_headers() {
     let app = create_test_app().await;
 
@@ -379,7 +379,7 @@ async fn test_get_headers() {
     assert!(headers.get("Content-Length").is_some());
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_head_nonexistent_file() {
     let app = create_test_app().await;
 
@@ -402,7 +402,7 @@ async fn test_head_nonexistent_file() {
     assert_eq!(body_bytes.len(), 0);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_head_existing_file() {
     let app = create_test_app().await;
 
@@ -467,7 +467,7 @@ async fn test_head_existing_file() {
     assert_eq!(body_bytes.len(), 0);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_delete_nonexistent_file() {
     let app = create_test_app().await;
 
@@ -491,7 +491,7 @@ async fn test_delete_nonexistent_file() {
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_delete_file() {
     let (mut app, state) = create_test_app_with_state().await;
     use tower::Service;
@@ -580,7 +580,7 @@ async fn test_delete_file() {
     assert_eq!(get_response.status(), StatusCode::NOT_FOUND);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_dedup_refcount_increment() {
     let app = create_test_app().await;
 
@@ -697,7 +697,7 @@ async fn test_dedup_refcount_increment() {
     assert_eq!(get3.status(), StatusCode::OK);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_dedup_blob_deleted_when_refcount_zero() {
     let (mut app, state) = create_test_app_with_state().await;
     use tower::Service;
@@ -860,7 +860,7 @@ async fn test_dedup_blob_deleted_when_refcount_zero() {
     assert_eq!(get2.status(), StatusCode::NOT_FOUND);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_dedup_partial_deletion() {
     let app = create_test_app().await;
 
@@ -1013,7 +1013,7 @@ async fn test_dedup_partial_deletion() {
     assert_eq!(get2.status(), StatusCode::NOT_FOUND);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_dedup_update_same_path() {
     use tower::Service;
 
@@ -1127,7 +1127,7 @@ async fn test_dedup_update_same_path() {
     assert_eq!(decompressed, content_v2);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_list_files_empty() {
     let app = create_test_app().await;
 
@@ -1151,7 +1151,7 @@ async fn test_list_files_empty() {
     assert_eq!(body_str, "");
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_list_files_basic() {
     use tower::Service;
     let mut app = create_test_app().await;
@@ -1291,7 +1291,7 @@ async fn test_list_files_basic() {
     assert_eq!(all_files.len(), 3);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_list_files_with_timestamp() {
     use tower::Service;
     let mut app = create_test_app().await;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -87,11 +87,11 @@ async fn create_test_app_with_state() -> (Router, Arc<s3dedup::AppState>) {
     };
 
     let kvstorage = KVStorage::new(&config).await.unwrap();
-    let locks = LocksStorage::new(&config.locks_type);
+    let locks = LocksStorage::new(config.locks_type);
     let s3storage = S3Storage::new(&config).await.unwrap();
 
     let app_state = Arc::new(AppState {
-        bucket_name: config.name.clone(),
+        bucket_name: config.name.into(),
         kvstorage: Arc::new(Mutex::new(kvstorage)),
         locks: Arc::new(Mutex::new(locks)),
         s3storage: Arc::new(Mutex::new(s3storage)),

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -91,9 +91,9 @@ async fn create_test_app_with_state() -> (Router, Arc<s3dedup::AppState>) {
     let s3storage = S3Storage::new(&config).await.unwrap();
 
     let app_state = Arc::new(AppState {
-        bucket_name: config.name.into(),
+        bucket_name: config.name,
         kvstorage: Arc::new(Mutex::new(kvstorage)),
-        locks: Arc::new(Mutex::new(locks)),
+        locks,
         s3storage: Arc::new(Mutex::new(s3storage)),
         filetracker_client: None,
         metrics: Arc::new(s3dedup::metrics::Metrics::new()),

--- a/tests/metrics_test.rs
+++ b/tests/metrics_test.rs
@@ -47,7 +47,7 @@ async fn create_test_app_state() -> Arc<AppState> {
     let app_state = AppState::new(&config).await.unwrap();
     app_state.kvstorage.lock().await.setup().await.unwrap();
 
-    Arc::new(app_state)
+    app_state
 }
 
 #[tokio::test]
@@ -284,7 +284,7 @@ async fn test_migration_active_metric() {
 
     let app = Router::new()
         .route("/metrics", get(s3dedup::routes::metrics::metrics_handler))
-        .with_state(Arc::new(app_state));
+        .with_state(app_state);
 
     let response = app
         .oneshot(

--- a/tests/metrics_test.rs
+++ b/tests/metrics_test.rs
@@ -50,7 +50,7 @@ async fn create_test_app_state() -> Arc<AppState> {
     app_state
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_metrics_endpoint_exists() {
     let app_state = create_test_app_state().await;
 
@@ -71,7 +71,7 @@ async fn test_metrics_endpoint_exists() {
     assert_eq!(response.status(), StatusCode::OK);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_metrics_format() {
     let app_state = create_test_app_state().await;
 
@@ -115,7 +115,7 @@ async fn test_metrics_format() {
     // We just check that the metrics endpoint returns valid Prometheus format
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_metrics_after_get_request() {
     let app_state = create_test_app_state().await;
 
@@ -173,7 +173,7 @@ async fn test_metrics_after_get_request() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_metrics_uptime_increases() {
     let app_state = create_test_app_state().await;
 
@@ -238,7 +238,7 @@ async fn test_metrics_uptime_increases() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_migration_active_metric() {
     // Create unique identifier
     let thread_id = std::thread::current().id();
@@ -321,7 +321,7 @@ async fn test_migration_active_metric() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_metrics_json_endpoint() {
     let app_state = create_test_app_state().await;
 

--- a/tests/migration_test.rs
+++ b/tests/migration_test.rs
@@ -212,7 +212,7 @@ async fn create_test_app_state() -> Arc<AppState> {
     app_state
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_offline_migration_empty() {
     let (_mock_state, url) = create_mock_filetracker().await;
     let app_state = create_test_app_state().await;
@@ -228,7 +228,7 @@ async fn test_offline_migration_empty() {
     assert_eq!(stats.skipped, 0);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_offline_migration_single_file() {
     let (mock_state, url) = create_mock_filetracker().await;
     let app_state = create_test_app_state().await;
@@ -259,7 +259,7 @@ async fn test_offline_migration_single_file() {
     assert!(modified > 0);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_offline_migration_multiple_files() {
     let (mock_state, url) = create_mock_filetracker().await;
     let app_state = create_test_app_state().await;
@@ -296,7 +296,7 @@ async fn test_offline_migration_multiple_files() {
     }
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_offline_migration_skips_existing() {
     let (mock_state, url) = create_mock_filetracker().await;
     let app_state = create_test_app_state().await;
@@ -322,7 +322,7 @@ async fn test_offline_migration_skips_existing() {
     assert_eq!(stats.skipped, 2);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_migration_deduplication() {
     let (mock_state, url) = create_mock_filetracker().await;
     let app_state = create_test_app_state().await;
@@ -389,7 +389,7 @@ async fn test_migration_deduplication() {
 
 // Live migration tests
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_live_migration_get_fallback() {
     let (mock_state, url) = create_mock_filetracker().await;
     let app_state = create_test_app_state().await;
@@ -442,7 +442,7 @@ async fn test_live_migration_get_fallback() {
     assert!(modified > 0, "File should be migrated to s3dedup");
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_live_migration_put_dual_write() {
     let (mock_state, url) = create_mock_filetracker().await;
     let app_state = create_test_app_state().await;
@@ -507,7 +507,7 @@ async fn test_live_migration_put_dual_write() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_live_migration_delete_dual_delete() {
     let (mock_state, url) = create_mock_filetracker().await;
     let app_state = create_test_app_state().await;
@@ -590,7 +590,7 @@ async fn test_live_migration_delete_dual_delete() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_live_migration_get_not_found_in_both() {
     let (_mock_state, url) = create_mock_filetracker().await;
     let app_state = create_test_app_state().await;
@@ -627,7 +627,7 @@ async fn test_live_migration_get_not_found_in_both() {
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_live_migration_get_fallback_response_data() {
     let (mock_state, url) = create_mock_filetracker().await;
     let app_state = create_test_app_state().await;
@@ -691,7 +691,7 @@ async fn test_live_migration_get_fallback_response_data() {
     assert_eq!(&decompressed[..], test_data);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_live_migration_subsequent_get_from_s3dedup() {
     let (mock_state, url) = create_mock_filetracker().await;
     let app_state = create_test_app_state().await;

--- a/tests/migration_test.rs
+++ b/tests/migration_test.rs
@@ -195,11 +195,11 @@ async fn create_test_app_state() -> Arc<AppState> {
     };
 
     let kvstorage = KVStorage::new(&config).await.unwrap();
-    let locks = LocksStorage::new(&config.locks_type);
+    let locks = LocksStorage::new(config.locks_type);
     let s3storage = S3Storage::new(&config).await.unwrap();
 
     let app_state = Arc::new(AppState {
-        bucket_name: config.name.clone(),
+        bucket_name: config.name.into(),
         kvstorage: Arc::new(tokio::sync::Mutex::new(kvstorage)),
         locks: Arc::new(tokio::sync::Mutex::new(locks)),
         s3storage: Arc::new(tokio::sync::Mutex::new(s3storage)),

--- a/tests/migration_test.rs
+++ b/tests/migration_test.rs
@@ -199,9 +199,9 @@ async fn create_test_app_state() -> Arc<AppState> {
     let s3storage = S3Storage::new(&config).await.unwrap();
 
     let app_state = Arc::new(AppState {
-        bucket_name: config.name.into(),
+        bucket_name: config.name,
         kvstorage: Arc::new(tokio::sync::Mutex::new(kvstorage)),
-        locks: Arc::new(tokio::sync::Mutex::new(locks)),
+        locks,
         s3storage: Arc::new(tokio::sync::Mutex::new(s3storage)),
         filetracker_client: None,
         metrics: Arc::new(s3dedup::metrics::Metrics::new()),

--- a/tests/migration_test.rs
+++ b/tests/migration_test.rs
@@ -691,6 +691,82 @@ async fn test_live_migration_get_fallback_response_data() {
     assert_eq!(&decompressed[..], test_data);
 }
 
+/// This test validates the critical deadlock fix in src/routes/ft/get_file.rs:66
+///
+/// Deadlock scenario WITHOUT the fix:
+/// 1. ft_get_file acquires a SHARED lock on the file (get_file.rs:24)
+/// 2. File not found in s3dedup (modified_time == 0), found in filetracker
+/// 3. Calls migrate_single_file_from_metadata while STILL HOLDING the shared lock
+/// 4. Migration tries to acquire EXCLUSIVE lock on the SAME file (migration/mod.rs:167)
+/// 5. Exclusive lock waits for shared lock to release → DEADLOCK (RwLock semantics)
+///
+/// The fix (get_file.rs:66): drop(_guard) before calling migration
+///
+/// This test would HANG/TIMEOUT without the drop, proving the fix is necessary.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_live_migration_get_no_deadlock_on_fallback() {
+    let (mock_state, url) = create_mock_filetracker().await;
+    let app_state = create_test_app_state().await;
+
+    // Add a file ONLY to filetracker (not in s3dedup) to trigger fallback migration
+    let test_data = b"File that triggers on-the-fly migration";
+    mock_state
+        .add_file("deadlock_test.txt", test_data.to_vec())
+        .await;
+
+    // Create app state with filetracker client (enables live migration mode)
+    let app_state_with_ft = Arc::new(AppState {
+        bucket_name: app_state.bucket_name.clone(),
+        kvstorage: app_state.kvstorage.clone(),
+        locks: app_state.locks.clone(),
+        s3storage: app_state.s3storage.clone(),
+        filetracker_client: Some(Arc::new(FiletrackerClient::new(url))),
+        metrics: Arc::new(s3dedup::metrics::Metrics::new()),
+    });
+
+    // Create router
+    let app = Router::new()
+        .route(
+            "/ft/files/{*path}",
+            axum::routing::get(s3dedup::routes::ft::get_file::ft_get_file),
+        )
+        .with_state(app_state_with_ft.clone());
+
+    // Make GET request with timeout to detect deadlocks quickly
+    // Without the drop(_guard) fix in get_file.rs:66, this would deadlock and timeout
+    let response = tokio::time::timeout(
+        tokio::time::Duration::from_secs(5),
+        app.oneshot(
+            axum::http::Request::builder()
+                .uri("/ft/files/deadlock_test.txt")
+                .body(Body::empty())
+                .unwrap(),
+        ),
+    )
+    .await
+    .expect("Request timed out - likely deadlock! Check that get_file.rs drops shared lock before migration")
+    .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // Verify file was successfully migrated to s3dedup
+    let modified = app_state_with_ft
+        .kvstorage
+        .lock()
+        .await
+        .get_modified(&app_state_with_ft.bucket_name, "deadlock_test.txt")
+        .await
+        .unwrap();
+    assert!(modified > 0, "File should be migrated to s3dedup");
+
+    // Verify response data is correct
+    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let decompressed = s3dedup::routes::ft::storage_helpers::decompress_gzip(&body_bytes).unwrap();
+    assert_eq!(&decompressed[..], test_data);
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn test_live_migration_subsequent_get_from_s3dedup() {
     let (mock_state, url) = create_mock_filetracker().await;


### PR DESCRIPTION
Main thing is changing Lock trait

Why I've done it the way I've done it:
- probably there would be more lock types selected at runtime, thus we need `dyn` compatibility
- I'm pretty sure other locks won't use `RwLock`, so we use marker traits (`SharedLockGuard`, `ExclusiveLockGuard`)
- because `RwLockReadGuard`/`RwLockWriteGuard` takes reference to locked `RwLock`, we need to split some logic (into `prepare_lock` and `acquire_shared`/`acquire_exclusive` calls) and add some lifetime magic
- because `AppState` needs to be `Send` (it's passed in `tokio::spawn`), we need guards to be `Send`, so `std::sync::RwLock` was ported to `tokio::sync::RwLock`, and that also required changing locks trait to `#[async_trait]`